### PR TITLE
#93 ExchangeItems from external functions properly transited

### DIFF
--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/.project
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>AllocatedExchangeItemTransition</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.afm
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_KwG-4DjuEe2pxs2FTpRzaA">
+  <viewpointReferences id="_KwbvADjuEe2pxs2FTpRzaA" vpId="org.polarsys.capella.core.viewpoint" version="6.0.0"/>
+</metadata:Metadata>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.aird
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.aird
@@ -1,0 +1,468 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/6.0.0" xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/6.0.0" xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/6.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_KwHl8DjuEe2pxs2FTpRzaA" selectedViews="_KwpKYDjuEe2pxs2FTpRzaA _KxYxQDjuEe2pxs2FTpRzaA _K2X-8DjuEe2pxs2FTpRzaA _K3W2YDjuEe2pxs2FTpRzaA _K5PFsDjuEe2pxs2FTpRzaA _K6j7YDjuEe2pxs2FTpRzaA _K69kADjuEe2pxs2FTpRzaA" version="15.0.0.202201261500">
+    <semanticResources>AllocatedExchangeItemTransition.afm</semanticResources>
+    <semanticResources>AllocatedExchangeItemTransition.capella</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_KwpKYDjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_KxYxQDjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_PkvykDjuEe2pxs2FTpRzaA" name="[PAB] Physical System" repPath="#_PktWUDjuEe2pxs2FTpRzaA" changeId="7d0c3d48-5a42-406c-9e61-7f4e4463be7b">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_PkxAszjuEe2pxs2FTpRzaA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PkxAtDjuEe2pxs2FTpRzaA" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_PkxAtTjuEe2pxs2FTpRzaA" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#c1091b6a-b983-48dd-8d41-d9443bdc1846"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_K2X-8DjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_K3W2YDjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_0IYSIDjvEe2pxs2FTpRzaA" name="[PFCD] FunctionalChain 1" repPath="#_0IXEADjvEe2pxs2FTpRzaA" changeId="a1e1e3fc-eb17-4dd7-a596-e3d9b719efbb">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="AllocatedExchangeItemTransition.capella#457182b7-e290-4436-9ce8-4454d0c6cace"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_K5PFsDjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_K6j7YDjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_K69kADjuEe2pxs2FTpRzaA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_PktWUDjuEe2pxs2FTpRzaA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_PkxAsDjuEe2pxs2FTpRzaA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_PkxAsTjuEe2pxs2FTpRzaA" type="Sirius" element="_PktWUDjuEe2pxs2FTpRzaA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_QA14sDjuEe2pxs2FTpRzaA" type="2002" element="_QAt84DjuEe2pxs2FTpRzaA">
+          <children xmi:type="notation:Node" xmi:id="_QA14szjuEe2pxs2FTpRzaA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_QA14tDjuEe2pxs2FTpRzaA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_Q4OzsDjuEe2pxs2FTpRzaA" type="3008" element="_Q4IGADjuEe2pxs2FTpRzaA">
+              <children xmi:type="notation:Node" xmi:id="_Q4OzszjuEe2pxs2FTpRzaA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_Q4OztDjuEe2pxs2FTpRzaA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_Vxj6IDjuEe2pxs2FTpRzaA" type="3007" element="_Vxb-UDjuEe2pxs2FTpRzaA">
+                  <children xmi:type="notation:Node" xmi:id="_Vxj6IzjuEe2pxs2FTpRzaA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_Vxj6JDjuEe2pxs2FTpRzaA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_Vxj6JTjuEe2pxs2FTpRzaA" type="3003" element="_VxclYDjuEe2pxs2FTpRzaA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_Vxj6JjjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vxj6JzjuEe2pxs2FTpRzaA"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_zf9csDjuEe2pxs2FTpRzaA" type="3001" element="_zfxPcDjuEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_zf-DwDjuEe2pxs2FTpRzaA" visible="false" type="5001">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_zf-DwTjuEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_zgExcDjuEe2pxs2FTpRzaA" type="3005" element="_zfx2gDjuEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_zgExcTjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zgExcjjuEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_zf9csTjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zf9csjjuEe2pxs2FTpRzaA" x="133" y="30" width="10" height="10"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_1LejUDjuEe2pxs2FTpRzaA" type="3001" element="_1LX1oDjuEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_1LfKYDjuEe2pxs2FTpRzaA" visible="false" type="5001">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_1LfKYTjuEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_1Lkp8DjuEe2pxs2FTpRzaA" type="3005" element="_1LX1oTjuEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_1Lkp8TjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1Lkp8jjuEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_1LejUTjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1LejUjjuEe2pxs2FTpRzaA" x="133" y="10" width="10" height="10"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_Vxj6ITjuEe2pxs2FTpRzaA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vxj6IjjuEe2pxs2FTpRzaA" x="25" y="44" width="141" height="81"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_W08CsDjuEe2pxs2FTpRzaA" type="3007" element="_W01VADjuEe2pxs2FTpRzaA">
+                  <children xmi:type="notation:Node" xmi:id="_W08pwDjuEe2pxs2FTpRzaA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_W08pwTjuEe2pxs2FTpRzaA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_W08pwjjuEe2pxs2FTpRzaA" type="3003" element="_W018EDjuEe2pxs2FTpRzaA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_W08pwzjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W08pxDjuEe2pxs2FTpRzaA"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_x-ZjUDjuEe2pxs2FTpRzaA" type="3001" element="_x-SOkDjuEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_x-ZjUzjuEe2pxs2FTpRzaA" visible="false" type="5001">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_x-ZjVDjuEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_x-g4EDjuEe2pxs2FTpRzaA" type="3005" element="_x-SOkTjuEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_x-g4ETjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x-g4EjjuEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_x-ZjUTjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_x-ZjUjjuEe2pxs2FTpRzaA" x="-2" y="10" width="10" height="10"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_0kL50DjuEe2pxs2FTpRzaA" type="3001" element="_0kDW8DjuEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_0kL50zjuEe2pxs2FTpRzaA" visible="false" type="5001">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_0kL51DjuEe2pxs2FTpRzaA" x="-39" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_0kTOkDjuEe2pxs2FTpRzaA" type="3005" element="_0kDW8TjuEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_0kTOkTjuEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0kTOkjjuEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_0kL50TjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0kL50jjuEe2pxs2FTpRzaA" x="-2" y="30" width="10" height="10"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_W08CsTjuEe2pxs2FTpRzaA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W08CsjjuEe2pxs2FTpRzaA" x="365" y="44" width="161" height="81"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_JQZqMDjvEe2pxs2FTpRzaA" type="3008" element="_JQSVcDjvEe2pxs2FTpRzaA">
+                  <children xmi:type="notation:Node" xmi:id="_JQZqMzjvEe2pxs2FTpRzaA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_JQZqNDjvEe2pxs2FTpRzaA" type="7002">
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_JQZqNTjvEe2pxs2FTpRzaA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_JQZqNjjvEe2pxs2FTpRzaA"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_VdhHUDjvEe2pxs2FTpRzaA" type="3012" element="_VdZLgDjvEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_VdhuYDjvEe2pxs2FTpRzaA" visible="false" type="5010">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_VdhuYTjvEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_Vdn1ADjvEe2pxs2FTpRzaA" type="3005" element="_VdZykDjvEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_Vdn1ATjvEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Vdn1AjjvEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_VdhHUTjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VdhHUjjvEe2pxs2FTpRzaA" x="153" y="120" width="10" height="10"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_WqOyEDjvEe2pxs2FTpRzaA" type="3012" element="_WqGPMDjvEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_WqOyEzjvEe2pxs2FTpRzaA" visible="false" type="5010">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_WqOyFDjvEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_WqURoDjvEe2pxs2FTpRzaA" type="3005" element="_WqG2QDjvEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WqURoTjvEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WqURojjvEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_WqOyETjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WqOyEjjvEe2pxs2FTpRzaA" x="153" y="50" width="10" height="10"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_JQZqMTjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_JQZqMjjvEe2pxs2FTpRzaA" x="35" y="204" width="163" height="153"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_QkdtsDjvEe2pxs2FTpRzaA" type="3008" element="_QkVx4DjvEe2pxs2FTpRzaA">
+                  <children xmi:type="notation:Node" xmi:id="_QkdtszjvEe2pxs2FTpRzaA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_QkdttDjvEe2pxs2FTpRzaA" type="7002">
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_QkdttTjvEe2pxs2FTpRzaA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_QkdttjjvEe2pxs2FTpRzaA"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_TGio4DjvEe2pxs2FTpRzaA" type="3012" element="_TGbUIDjvEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_TGio4zjvEe2pxs2FTpRzaA" visible="false" type="5010">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_TGio5DjvEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_TGnhYDjvEe2pxs2FTpRzaA" type="3005" element="_TGbUITjvEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_TGoIcDjvEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TGoIcTjvEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_TGio4TjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TGio4jjvEe2pxs2FTpRzaA" x="-2" y="50" width="10" height="10"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_WRFSQDjvEe2pxs2FTpRzaA" type="3012" element="_WQ99gDjvEe2pxs2FTpRzaA">
+                    <children xmi:type="notation:Node" xmi:id="_WRFSQzjvEe2pxs2FTpRzaA" visible="false" type="5010">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_WRFSRDjvEe2pxs2FTpRzaA" x="11" y="-5"/>
+                    </children>
+                    <children xmi:type="notation:Node" xmi:id="_WRLY4DjvEe2pxs2FTpRzaA" type="3005" element="_WQ99gTjvEe2pxs2FTpRzaA">
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_WRLY4TjvEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WRLY4jjvEe2pxs2FTpRzaA"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_WRFSQTjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WRFSQjjvEe2pxs2FTpRzaA" x="-2" y="120" width="10" height="10"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_QkdtsTjvEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QkdtsjjvEe2pxs2FTpRzaA" x="315" y="204" width="183" height="153"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_Q4OztTjuEe2pxs2FTpRzaA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_Q4OztjjuEe2pxs2FTpRzaA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Q4OzsTjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8" italic="true"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Q4OzsjjuEe2pxs2FTpRzaA" x="35" y="54" width="553" height="433"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_QA14tTjuEe2pxs2FTpRzaA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_QA14tjjuEe2pxs2FTpRzaA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_QA14sTjuEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QA14sjjuEe2pxs2FTpRzaA" x="320" y="290" width="633" height="533"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_PkxAsjjuEe2pxs2FTpRzaA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_ZzwHwDjvEe2pxs2FTpRzaA" type="4001" element="_ZzkhkDjvEe2pxs2FTpRzaA" source="_0kL50DjuEe2pxs2FTpRzaA" target="_zf9csDjuEe2pxs2FTpRzaA">
+          <children xmi:type="notation:Node" xmi:id="_Zzwu0DjvEe2pxs2FTpRzaA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zzwu0TjvEe2pxs2FTpRzaA" x="4" y="7"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Zzwu0jjvEe2pxs2FTpRzaA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zzwu0zjvEe2pxs2FTpRzaA" y="11"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Zzwu1DjvEe2pxs2FTpRzaA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zzwu1TjvEe2pxs2FTpRzaA" x="4" y="11"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ZzwHwTjvEe2pxs2FTpRzaA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ZzwHwjjvEe2pxs2FTpRzaA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZzwHwzjvEe2pxs2FTpRzaA" points="[-5, 0, 200, 0]$[-200, 0, 5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zzwu1jjvEe2pxs2FTpRzaA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zzwu1zjvEe2pxs2FTpRzaA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_kp7nIDjvEe2pxs2FTpRzaA" type="4001" element="_kpwoADjvEe2pxs2FTpRzaA" source="_WRFSQDjvEe2pxs2FTpRzaA" target="_VdhHUDjvEe2pxs2FTpRzaA">
+          <children xmi:type="notation:Node" xmi:id="_kp7nJDjvEe2pxs2FTpRzaA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kp7nJTjvEe2pxs2FTpRzaA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kp7nJjjvEe2pxs2FTpRzaA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kp7nJzjvEe2pxs2FTpRzaA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_kp7nKDjvEe2pxs2FTpRzaA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kp7nKTjvEe2pxs2FTpRzaA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_kp7nITjvEe2pxs2FTpRzaA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_kp7nIjjvEe2pxs2FTpRzaA" fontColor="9914954" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kp7nIzjvEe2pxs2FTpRzaA" points="[-5, 0, 120, 0]$[-120, 0, 5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kp8OMDjvEe2pxs2FTpRzaA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kp8OMTjvEe2pxs2FTpRzaA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Pk3HUDjuEe2pxs2FTpRzaA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Pk3HUTjuEe2pxs2FTpRzaA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_QAt84DjuEe2pxs2FTpRzaA" name="Node PC">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#d9d2fc43-566a-4365-ab9d-0d046f950fb1"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#d9d2fc43-566a-4365-ab9d-0d046f950fb1"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#3fc96af6-2833-43a0-b6b4-10da962950ac"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_QAt84TjuEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="GradientTopToBottom" backgroundColor="255,255,220" foregroundColor="255,252,183">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Q4IGADjuEe2pxs2FTpRzaA" name="BEHAVIOR PC">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#51e22897-9889-4f47-95a1-c0943f83d2b8"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#51e22897-9889-4f47-95a1-c0943f83d2b8"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#5892b130-2d27-4b33-aa6b-071ebf8b7b2d"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Q4ItEDjuEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <labelFormat>italic</labelFormat>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']"/>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_Vxb-UDjuEe2pxs2FTpRzaA" name="PhysicalFunction 1" width="5" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#64fd5d3a-0dca-4cbd-a0df-d21c068956a7"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#64fd5d3a-0dca-4cbd-a0df-d21c068956a7"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_zfxPcDjuEe2pxs2FTpRzaA" name="FIP 2" incomingEdges="_ZzkhkDjvEe2pxs2FTpRzaA" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="AllocatedExchangeItemTransition.capella#3dd48290-d17a-4173-8d91-a87a055eed4a"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="AllocatedExchangeItemTransition.capella#3dd48290-d17a-4173-8d91-a87a055eed4a"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_zfydkTjuEe2pxs2FTpRzaA"/>
+            <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+            <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+            <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_zfx2gDjuEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+          </ownedBorderedNodes>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_1LX1oDjuEe2pxs2FTpRzaA" name="FOP 1" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="AllocatedExchangeItemTransition.capella#9eb87c76-fa5b-42c2-b5fa-b09077e13a76"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="AllocatedExchangeItemTransition.capella#9eb87c76-fa5b-42c2-b5fa-b09077e13a76"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_1LX1ozjuEe2pxs2FTpRzaA"/>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_1LX1oTjuEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+          </ownedBorderedNodes>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:Square" uid="_VxclYDjuEe2pxs2FTpRzaA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_W01VADjuEe2pxs2FTpRzaA" name="PhysicalFunction 2" width="5" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#5d81b1e3-ceac-4ef8-96e4-410b90da620b"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#5d81b1e3-ceac-4ef8-96e4-410b90da620b"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_x-SOkDjuEe2pxs2FTpRzaA" name="FIP 1" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="AllocatedExchangeItemTransition.capella#0c17a944-894c-464b-8c57-6c3736b65711"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="AllocatedExchangeItemTransition.capella#0c17a944-894c-464b-8c57-6c3736b65711"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_x-TcsDjuEe2pxs2FTpRzaA"/>
+            <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+            <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+            <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_x-SOkTjuEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+          </ownedBorderedNodes>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_0kDW8DjuEe2pxs2FTpRzaA" name="FOP 2" outgoingEdges="_ZzkhkDjvEe2pxs2FTpRzaA" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="AllocatedExchangeItemTransition.capella#f7ed13eb-3210-4e41-aabd-c066bd0e8e56"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="AllocatedExchangeItemTransition.capella#f7ed13eb-3210-4e41-aabd-c066bd0e8e56"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_0kD-ADjuEe2pxs2FTpRzaA"/>
+            <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+            <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+            <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_0kDW8TjuEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+          </ownedBorderedNodes>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:Square" uid="_W018EDjuEe2pxs2FTpRzaA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_JQSVcDjvEe2pxs2FTpRzaA" name="BEHAVIOR PC SUB 1">
+          <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#a628d254-26a1-4ab1-b41d-04cb814e7bbe"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#a628d254-26a1-4ab1-b41d-04cb814e7bbe"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#bef24808-5b3a-490d-8f4f-f9d4ee21f9ea"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_VdZLgDjvEe2pxs2FTpRzaA" name="CP 1" incomingEdges="_kpwoADjvEe2pxs2FTpRzaA" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#64c38a3a-6d74-4b6e-a18d-b2760755e225"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#64c38a3a-6d74-4b6e-a18d-b2760755e225"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_VdZykjjvEe2pxs2FTpRzaA"/>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_VdZykDjvEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']/@conditionnalStyles.2/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']"/>
+          </ownedBorderedNodes>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WqGPMDjvEe2pxs2FTpRzaA" name="CP 2" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#c72bce99-0bdb-4573-a5f6-1c4870005d97"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#c72bce99-0bdb-4573-a5f6-1c4870005d97"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_WqG2QjjvEe2pxs2FTpRzaA"/>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_WqG2QDjvEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']/@conditionnalStyles.3/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']"/>
+          </ownedBorderedNodes>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_JQSVcTjvEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_QkVx4DjvEe2pxs2FTpRzaA" name="BEHAVIOR PC SUB 2">
+          <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#7f5b14d1-42ab-45ff-a559-02996f9411a0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="AllocatedExchangeItemTransition.capella#7f5b14d1-42ab-45ff-a559-02996f9411a0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#57a3c8dc-5f97-49f1-bf79-6d9ccc99c692"/>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_TGbUIDjvEe2pxs2FTpRzaA" name="CP 1" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#a05d9d6c-bd07-476d-9e1b-e2a1e1e1d2b6"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#a05d9d6c-bd07-476d-9e1b-e2a1e1e1d2b6"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_TGb7MTjvEe2pxs2FTpRzaA"/>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_TGbUITjvEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/InFlowPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']/@conditionnalStyles.2/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']"/>
+          </ownedBorderedNodes>
+          <ownedBorderedNodes xmi:type="diagram:DNode" uid="_WQ99gDjvEe2pxs2FTpRzaA" name="CP 2" outgoingEdges="_kpwoADjvEe2pxs2FTpRzaA" width="1" height="1">
+            <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#3b4a7c50-8dd3-4178-8e64-57596908ce2c"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="AllocatedExchangeItemTransition.capella#3b4a7c50-8dd3-4178-8e64-57596908ce2c"/>
+            <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_WQ-kkDjvEe2pxs2FTpRzaA"/>
+            <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_WQ99gTjvEe2pxs2FTpRzaA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.svg">
+              <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']/@conditionnalStyles.3/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@borderedNodeMappings[name='PAB_Port']"/>
+          </ownedBorderedNodes>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_QkVx4TjvEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']"/>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ZzkhkDjvEe2pxs2FTpRzaA" name="FunctionalExchange 1" sourceNode="_0kDW8DjuEe2pxs2FTpRzaA" targetNode="_zfxPcDjuEe2pxs2FTpRzaA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="AllocatedExchangeItemTransition.capella#bb4547d2-bf76-47b9-a299-e216fa557330"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="AllocatedExchangeItemTransition.capella#bb4547d2-bf76-47b9-a299-e216fa557330"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ZzlIoDjvEe2pxs2FTpRzaA" targetArrow="NoDecoration" centered="Both" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_ZzlIoTjvEe2pxs2FTpRzaA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ZzlIozjvEe2pxs2FTpRzaA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_ZzlIojjvEe2pxs2FTpRzaA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_kpwoADjvEe2pxs2FTpRzaA" name="C 1" sourceNode="_WQ99gDjvEe2pxs2FTpRzaA" targetNode="_VdZLgDjvEe2pxs2FTpRzaA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="AllocatedExchangeItemTransition.capella#293edf7c-81df-40d2-affc-98dde43154b5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentExchange" href="AllocatedExchangeItemTransition.capella#293edf7c-81df-40d2-affc-98dde43154b5"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_kpwoATjvEe2pxs2FTpRzaA" targetArrow="NoDecoration" centered="Both" strokeColor="74,74,151">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_Exchange']/@conditionnalStyles.3/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_kpwoAjjvEe2pxs2FTpRzaA" labelColor="74,74,151"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Pkt9YDjuEe2pxs2FTpRzaA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="AllocatedExchangeItemTransition.capella#c1091b6a-b983-48dd-8d41-d9443bdc1846"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_0IXEADjvEe2pxs2FTpRzaA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_0IZgQDjvEe2pxs2FTpRzaA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_0IZgQTjvEe2pxs2FTpRzaA" type="Sirius" element="_0IXEADjvEe2pxs2FTpRzaA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_r383kDjwEe2pxs2FTpRzaA" type="2001" element="_r3sY4DjwEe2pxs2FTpRzaA">
+          <children xmi:type="notation:Node" xmi:id="_r39eoDjwEe2pxs2FTpRzaA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_r39eoTjwEe2pxs2FTpRzaA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_r39epzjwEe2pxs2FTpRzaA" type="3003" element="_r3sY4TjwEe2pxs2FTpRzaA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_r39eqDjwEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r39eqTjwEe2pxs2FTpRzaA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_r383kTjwEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r383kjjwEe2pxs2FTpRzaA" x="560" y="250" width="100" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_r39eojjwEe2pxs2FTpRzaA" type="2001" element="_r3s_8DjwEe2pxs2FTpRzaA">
+          <children xmi:type="notation:Node" xmi:id="_r39epTjwEe2pxs2FTpRzaA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_r39epjjwEe2pxs2FTpRzaA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_r3-FsDjwEe2pxs2FTpRzaA" type="3003" element="_r3s_8TjwEe2pxs2FTpRzaA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_r3-FsTjwEe2pxs2FTpRzaA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r3-FsjjwEe2pxs2FTpRzaA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_r39eozjwEe2pxs2FTpRzaA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_r39epDjwEe2pxs2FTpRzaA" x="990" y="260" width="100" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_0IZgQjjvEe2pxs2FTpRzaA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_0IbVcDjvEe2pxs2FTpRzaA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_0IbVcTjvEe2pxs2FTpRzaA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_r3sY4DjwEe2pxs2FTpRzaA" name="PhysicalFunction 1" width="10" height="5" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="AllocatedExchangeItemTransition.capella#c4b15ff2-0592-49d1-8c4d-b8c26c46c42d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="AllocatedExchangeItemTransition.capella#c4b15ff2-0592-49d1-8c4d-b8c26c46c42d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#64fd5d3a-0dca-4cbd-a0df-d21c068956a7"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_r3sY4TjwEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_r3s_8DjwEe2pxs2FTpRzaA" name="PhysicalFunction 2" width="10" height="5" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="AllocatedExchangeItemTransition.capella#4cbbc428-9df1-4b07-88ff-e7b34f5ee7ad"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="AllocatedExchangeItemTransition.capella#4cbbc428-9df1-4b07-88ff-e7b34f5ee7ad"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="AllocatedExchangeItemTransition.capella#5d81b1e3-ceac-4ef8-96e4-410b90da620b"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_r3s_8TjwEe2pxs2FTpRzaA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_0IXEATjvEe2pxs2FTpRzaA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="AllocatedExchangeItemTransition.capella#457182b7-e290-4436-9ce8-4454d0c6cace"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.capella
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/AllocatedExchangeItemTest/AllocatedExchangeItemTransition.capella
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_6.0.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/6.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/6.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/6.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/6.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.pa.deployment="http://www.polarsys.org/capella/core/pa/deployment/6.0.0"
+    id="9d1f08eb-17a4-439e-ba63-b98ab690c4e3"
+    name="AllocatedExchangeItemTransition">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="df0889db-0c86-4af2-9e03-f455f10cdc6a"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="a0f457f7-04c2-4a7f-a8b2-cb0632ee01a9" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="87496c07-df12-4a93-b312-3643a02d0517" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="a1f071a7-b389-44dd-8121-c40278decf8e" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="11fb2908-7b34-40e9-a973-3ff733621208" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="fe4f983d-5bc5-4100-b9f3-52df5f7d7c37" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="f975f6dc-a2ff-4d91-853a-e7718e4f95e0" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="bfe16ed6-511c-4033-a1b7-de2110f402c1" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="450b39fd-ef3a-4158-bf32-9515121f5e9d"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="abdfa2ca-79a4-4abd-961b-0bf52393a673" name="AllocatedExchangeItemTransition">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="d74a1a35-0993-4fda-bdc3-08047fc2bd05" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="e1f93d73-b22a-497a-8e76-ac2974dfa537" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="ec793973-21d4-4f5a-9942-f4cd354e7926" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="b67ae872-d400-4bc1-8f85-06f478bb7e40" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="ac9be5ee-3094-4c1f-a2ea-61b29f0452f1" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="507857d4-5933-4e9d-97ef-74bb84bcb35e" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="a513d44a-3a48-4be4-a4e8-1aa9095ee292"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="e6a99b35-04c1-4ad4-91a8-cc06cd58555c"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="4c2dddd9-7810-4d62-a183-f006fe96a4a4" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="d5d7f198-a20d-4bcf-827c-70a4f74cb372" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="bf217adf-1f06-47da-abc0-257eb17a6cd5" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="4eaccea2-89ff-44a2-9c17-5c89864e8070" targetElement="#ec793973-21d4-4f5a-9942-f4cd354e7926"
+              sourceElement="#bf217adf-1f06-47da-abc0-257eb17a6cd5"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="a7e49ff9-3e91-4613-94ab-08d1fd8b8592" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="9d93302a-7eec-410a-b1bf-07c32ad36750" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="8f047c1f-6671-4488-95d1-49783a87d956" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="7c388712-0c2a-433b-8cc4-f9e3862e1400" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="2510e73b-c52d-4278-b268-49b8d36014e5" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="c8e1fce1-16db-451b-8456-1e0311498f57" name="True" abstractType="#2510e73b-c52d-4278-b268-49b8d36014e5"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="c30f6d5a-abd9-455f-aff8-965e0c1a05cb" name="False" abstractType="#2510e73b-c52d-4278-b268-49b8d36014e5"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="6739abc8-ac45-47a2-9ffd-8bc7173422e4" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="df65e5f0-4527-4cb8-88f7-16f1c0941ea9" name="" abstractType="#6739abc8-ac45-47a2-9ffd-8bc7173422e4"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="93977bdc-6e34-48fe-a821-c7818eafaa75" name="" abstractType="#6739abc8-ac45-47a2-9ffd-8bc7173422e4"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="954d5048-b884-45b0-b334-826ce06888af" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="6e815e28-5394-4469-8993-815e3ce5c926" name="" abstractType="#1ca096d4-ba8f-40aa-83af-621e0a062599"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="23f25f94-0e70-41a8-a4a7-66a8b9b51dc5" name="" abstractType="#1ca096d4-ba8f-40aa-83af-621e0a062599"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5965f5b2-d4b4-4715-9bef-25058b3edab1" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="027289a2-d320-46a5-9346-4d7eab57b7ae" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4db1cb7a-98ef-41b5-9666-fd38466d9ccc" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="c4b52fed-ae7d-4b55-9740-50890e2bdc7e" name="" abstractType="#4db1cb7a-98ef-41b5-9666-fd38466d9ccc"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="6b9eb8b2-a0a9-4234-ad99-0b46a22d8948" abstractType="#4db1cb7a-98ef-41b5-9666-fd38466d9ccc"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="302a5cca-df97-4920-b4b2-2e95eb1cccb4" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="4d27e279-8370-4d88-8d72-27721704dcb8" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="f2575de2-6ac4-40fb-929a-a1cf7df1b43e" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="16bc13cf-6e14-431a-b160-250a50b367b8" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="300ecabb-ffd9-442e-b629-ce9f4eabb8f6" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="90b6a516-a2e1-4993-bdc2-76bdf2fd16e8" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="1c4f96fc-32b3-4038-9dfa-143900b40e0a" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="3f34042a-2586-4287-9dea-84aab554bbfa" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="50d061a2-d9a6-4aa6-b5b6-2d2da122a963" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="407e2687-31d7-4108-9f00-7149daf53595" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="44d44587-f9ad-4932-b7ed-339398281f73" name="" abstractType="#407e2687-31d7-4108-9f00-7149daf53595"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="1ca096d4-ba8f-40aa-83af-621e0a062599" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="1bf5177a-d5d4-4d69-8e56-7588cb565681" name="" abstractType="#1ca096d4-ba8f-40aa-83af-621e0a062599"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4ee115f8-b949-4b96-9523-8ef27ba313d9" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="eee7809d-c882-4969-b0ff-7ee0c52c61b5" name="" abstractType="#4ee115f8-b949-4b96-9523-8ef27ba313d9"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="2e55f127-8dd8-4ae1-8024-7ec5ec3b1e75" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="0ce36540-af1c-4763-82ba-0366008e7951" name="" abstractType="#2e55f127-8dd8-4ae1-8024-7ec5ec3b1e75"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="96aa33e1-eef3-4774-8744-b8b01055472f" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="fdbcce20-3c9c-44b0-a07b-fef1e374330b"
+            name="System" abstractType="#eac53ac2-afb1-4bf5-b4cf-e539ef2e4df3"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="eac53ac2-afb1-4bf5-b4cf-e539ef2e4df3" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="3f4f97b3-6047-4e74-bced-bd9f1cab9408" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="f6123e1f-a03a-44c3-ab52-7f3a5f296064" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="443e5948-cb82-476c-aa2a-b02493834a8b"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="b48f823a-4c4c-48dc-8527-d585a4785668" targetElement="#d74a1a35-0993-4fda-bdc3-08047fc2bd05"
+          sourceElement="#4c2dddd9-7810-4d62-a183-f006fe96a4a4"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="8bfa97c5-43d0-49f0-8ce2-b9c1231151e1" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="b9c3e65b-aa4e-41de-bf41-e8f5106fac23" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="14a63d8b-ace3-43f1-b3b7-d35c371e0278" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="354d4f12-3f87-4f8a-ac17-d92cef58a8dd" targetElement="#bf217adf-1f06-47da-abc0-257eb17a6cd5"
+              sourceElement="#14a63d8b-ace3-43f1-b3b7-d35c371e0278"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="7d7722a0-71e4-46c7-86cd-23d2616f131e" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="4faed068-a819-46b4-a836-b7f371eba909" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="aaeab92d-354e-4d63-95bc-a71258615900" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="6f61a369-aaa4-4795-b2a3-30092237d315" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="27d6027f-659c-4a47-9b44-dcbc22072dfb"
+            name="Logical System" abstractType="#af667a38-5a94-4c92-92df-53fd66963c76"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="af667a38-5a94-4c92-92df-53fd66963c76" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="5f5a0519-63be-42d8-a484-4b265d5ee984" targetElement="#eac53ac2-afb1-4bf5-b4cf-e539ef2e4df3"
+              sourceElement="#af667a38-5a94-4c92-92df-53fd66963c76"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="059324f9-abe2-4687-98d1-f1cf0cbd9cbd" targetElement="#4c2dddd9-7810-4d62-a183-f006fe96a4a4"
+          sourceElement="#8bfa97c5-43d0-49f0-8ce2-b9c1231151e1"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="d412e424-e5bb-44ce-9a26-00bcb406a3b0" sid="d412e424-e5bb-44ce-9a26-00bcb406a3b0"
+        name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="d0291cb2-5188-4a1e-bde5-4d7740e8ee21" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="c005f45b-aa75-46e9-af52-d32f6e9301b3" name="Root Physical Function">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="457182b7-e290-4436-9ce8-4454d0c6cace" name="FunctionalChain 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="c4b15ff2-0592-49d1-8c4d-b8c26c46c42d" involved="#64fd5d3a-0dca-4cbd-a0df-d21c068956a7"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="4cbbc428-9df1-4b07-88ff-e7b34f5ee7ad" involved="#5d81b1e3-ceac-4ef8-96e4-410b90da620b"/>
+          </ownedFunctionalChains>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="64fd5d3a-0dca-4cbd-a0df-d21c068956a7" sid="64fd5d3a-0dca-4cbd-a0df-d21c068956a7"
+              name="PhysicalFunction 1">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="3dd48290-d17a-4173-8d91-a87a055eed4a" sid="3dd48290-d17a-4173-8d91-a87a055eed4a"
+                name="FIP 2"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="9eb87c76-fa5b-42c2-b5fa-b09077e13a76" sid="9eb87c76-fa5b-42c2-b5fa-b09077e13a76"
+                name="FOP 1" outgoingExchangeItems="#fd4e8de4-d839-438c-9da4-3653743bb129"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="5d81b1e3-ceac-4ef8-96e4-410b90da620b" sid="5d81b1e3-ceac-4ef8-96e4-410b90da620b"
+              name="PhysicalFunction 2">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="0c17a944-894c-464b-8c57-6c3736b65711" sid="0c17a944-894c-464b-8c57-6c3736b65711"
+                name="FIP 1" incomingExchangeItems="#d335f117-c19a-4466-91f2-e7dc83dd4218"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="f7ed13eb-3210-4e41-aabd-c066bd0e8e56" sid="f7ed13eb-3210-4e41-aabd-c066bd0e8e56"
+                name="FOP 2"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="2c876c28-ff1e-4cdd-81af-f025e012c2d5" name="PhysicalFunction 3"/>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="6b2543c0-70f2-45a0-85a7-5579fdd940c0" name="PhysicalFunction 4"/>
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="7a94fa7d-339b-4a99-9549-1937bdcdee62" targetElement="#14a63d8b-ace3-43f1-b3b7-d35c371e0278"
+              sourceElement="#c005f45b-aa75-46e9-af52-d32f6e9301b3"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="bb4547d2-bf76-47b9-a299-e216fa557330" sid="bb4547d2-bf76-47b9-a299-e216fa557330"
+              name="FunctionalExchange 1" target="#3dd48290-d17a-4173-8d91-a87a055eed4a"
+              source="#f7ed13eb-3210-4e41-aabd-c066bd0e8e56" exchangedItems="#f3685b18-6179-4aea-b249-91b4dcd537a9"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="642fea46-e66e-492f-b1ce-f08ac0486961" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="c47638f7-cab6-4290-a539-c405ad67c602" name="Interfaces">
+        <ownedInterfaces xsi:type="org.polarsys.capella.core.data.cs:Interface" id="974ded47-c9a6-4943-90e4-bd7bfedcafb1"
+            sid="974ded47-c9a6-4943-90e4-bd7bfedcafb1" name="Interface 1">
+          <ownedExchangeItemAllocations xsi:type="org.polarsys.capella.core.data.cs:ExchangeItemAllocation"
+              id="8681f44e-6829-424f-ab57-4908406b87be" sid="8681f44e-6829-424f-ab57-4908406b87be"
+              allocatedItem="#cb34546f-7606-47dc-863b-bb2065f3036a"/>
+        </ownedInterfaces>
+        <ownedInterfaces xsi:type="org.polarsys.capella.core.data.cs:Interface" id="16cc6322-3a12-4a2e-9b6a-b04943bd21c9"
+            sid="16cc6322-3a12-4a2e-9b6a-b04943bd21c9" name="Interface 2">
+          <ownedExchangeItemAllocations xsi:type="org.polarsys.capella.core.data.cs:ExchangeItemAllocation"
+              id="aeed14f1-5870-43fd-a0bc-7c9756d2b413" sid="aeed14f1-5870-43fd-a0bc-7c9756d2b413"
+              allocatedItem="#52b962c9-e551-4e50-b0ef-42eddd648b42"/>
+        </ownedInterfaces>
+      </ownedInterfacePkg>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="016ed42c-b6b0-4d96-bdea-507d2a3dbcc1" name="Data">
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="fd4e8de4-d839-438c-9da4-3653743bb129" sid="fd4e8de4-d839-438c-9da4-3653743bb129"
+            name="ExchangeItem FOP 1"/>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="d335f117-c19a-4466-91f2-e7dc83dd4218" sid="d335f117-c19a-4466-91f2-e7dc83dd4218"
+            name="ExchangeItem FIP 1"/>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="f3685b18-6179-4aea-b249-91b4dcd537a9" sid="f3685b18-6179-4aea-b249-91b4dcd537a9"
+            name="ExchangeItem FunctionalExchange 1"/>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="69d78fb0-3614-485b-9ce6-b9360866175c" sid="69d78fb0-3614-485b-9ce6-b9360866175c"
+            name="ExchangeItem ComponentExchange"/>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="cb34546f-7606-47dc-863b-bb2065f3036a" sid="cb34546f-7606-47dc-863b-bb2065f3036a"
+            name="ExchangeItem ITF 1"/>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="52b962c9-e551-4e50-b0ef-42eddd648b42" sid="52b962c9-e551-4e50-b0ef-42eddd648b42"
+            name="ExchangeItem ITF 2"/>
+      </ownedDataPkg>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="671362a2-e14a-492b-9091-b4664ff3c52d" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="f9f6e367-b24c-49ab-bf59-d785c66c29b6"
+            name="Physical System" abstractType="#c1091b6a-b983-48dd-8d41-d9443bdc1846"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="c1091b6a-b983-48dd-8d41-d9443bdc1846" name="Physical System">
+          <ownedComponentExchanges xsi:type="org.polarsys.capella.core.data.fa:ComponentExchange"
+              id="293edf7c-81df-40d2-affc-98dde43154b5" sid="293edf7c-81df-40d2-affc-98dde43154b5"
+              name="C 1" convoyedInformations="#69d78fb0-3614-485b-9ce6-b9360866175c"
+              source="#3b4a7c50-8dd3-4178-8e64-57596908ce2c" target="#64c38a3a-6d74-4b6e-a18d-b2760755e225"
+              kind="FLOW"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="d9d2fc43-566a-4365-ab9d-0d046f950fb1"
+              sid="d9d2fc43-566a-4365-ab9d-0d046f950fb1" name="Node PC" abstractType="#3fc96af6-2833-43a0-b6b4-10da962950ac">
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="b910ed56-41e3-4fa0-a407-59857fdb19c9" deployedElement="#51e22897-9889-4f47-95a1-c0943f83d2b8"
+                location="#d9d2fc43-566a-4365-ab9d-0d046f950fb1"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="51e22897-9889-4f47-95a1-c0943f83d2b8"
+              sid="51e22897-9889-4f47-95a1-c0943f83d2b8" name="BEHAVIOR PC" abstractType="#5892b130-2d27-4b33-aa6b-071ebf8b7b2d">
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="12e4058c-e916-409a-ab5b-e1d44b9194b8" deployedElement="#a628d254-26a1-4ab1-b41d-04cb814e7bbe"
+                location="#51e22897-9889-4f47-95a1-c0943f83d2b8"/>
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="77373c9b-1f3a-4719-81a0-9580c193fa8c" deployedElement="#7f5b14d1-42ab-45ff-a559-02996f9411a0"
+                location="#51e22897-9889-4f47-95a1-c0943f83d2b8"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a628d254-26a1-4ab1-b41d-04cb814e7bbe"
+              sid="a628d254-26a1-4ab1-b41d-04cb814e7bbe" name="BEHAVIOR PC SUB 1"
+              abstractType="#bef24808-5b3a-490d-8f4f-f9d4ee21f9ea"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="7f5b14d1-42ab-45ff-a559-02996f9411a0"
+              sid="7f5b14d1-42ab-45ff-a559-02996f9411a0" name="BEHAVIOR PC SUB 2"
+              abstractType="#57a3c8dc-5f97-49f1-bf79-6d9ccc99c692"/>
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="11b485dc-8bfe-486b-89de-62fbe46c16d1" targetElement="#af667a38-5a94-4c92-92df-53fd66963c76"
+              sourceElement="#c1091b6a-b983-48dd-8d41-d9443bdc1846"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="3fc96af6-2833-43a0-b6b4-10da962950ac" sid="3fc96af6-2833-43a0-b6b4-10da962950ac"
+              name="Node PC" nature="NODE"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="5892b130-2d27-4b33-aa6b-071ebf8b7b2d" sid="5892b130-2d27-4b33-aa6b-071ebf8b7b2d"
+              name="BEHAVIOR PC" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="c25d548f-1473-4f1a-befc-5f9373eccccc" sid="c25d548f-1473-4f1a-befc-5f9373eccccc"
+                targetElement="#64fd5d3a-0dca-4cbd-a0df-d21c068956a7" sourceElement="#5892b130-2d27-4b33-aa6b-071ebf8b7b2d"/>
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="9f723ca6-1f43-470c-9fd3-84e0d65a5966" sid="9f723ca6-1f43-470c-9fd3-84e0d65a5966"
+                targetElement="#5d81b1e3-ceac-4ef8-96e4-410b90da620b" sourceElement="#5892b130-2d27-4b33-aa6b-071ebf8b7b2d"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="bef24808-5b3a-490d-8f4f-f9d4ee21f9ea" sid="bef24808-5b3a-490d-8f4f-f9d4ee21f9ea"
+              name="BEHAVIOR PC SUB 1" nature="BEHAVIOR">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="64c38a3a-6d74-4b6e-a18d-b2760755e225" sid="64c38a3a-6d74-4b6e-a18d-b2760755e225"
+                name="CP 1" orientation="IN" kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="c72bce99-0bdb-4573-a5f6-1c4870005d97" sid="c72bce99-0bdb-4573-a5f6-1c4870005d97"
+                name="CP 2" providedInterfaces="#974ded47-c9a6-4943-90e4-bd7bfedcafb1"
+                orientation="OUT" kind="FLOW"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="57a3c8dc-5f97-49f1-bf79-6d9ccc99c692" sid="57a3c8dc-5f97-49f1-bf79-6d9ccc99c692"
+              name="BEHAVIOR PC SUB 2" nature="BEHAVIOR">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="a05d9d6c-bd07-476d-9e1b-e2a1e1e1d2b6" sid="a05d9d6c-bd07-476d-9e1b-e2a1e1e1d2b6"
+                name="CP 1" requiredInterfaces="#16cc6322-3a12-4a2e-9b6a-b04943bd21c9"
+                orientation="IN" kind="FLOW"/>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.fa:ComponentPort"
+                id="3b4a7c50-8dd3-4178-8e64-57596908ce2c" sid="3b4a7c50-8dd3-4178-8e64-57596908ce2c"
+                name="CP 2" orientation="OUT" kind="FLOW"/>
+          </ownedPhysicalComponents>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="1365ea44-5578-4cdd-a89b-56efa91e2d10" targetElement="#8bfa97c5-43d0-49f0-8ce2-b9c1231151e1"
+          sourceElement="#d412e424-e5bb-44ce-9a26-00bcb406a3b0"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="1a52d585-a722-4e9a-824e-e0992cb45280" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="64eedd46-b64d-4d11-8f71-aff405dc192b" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="b0cf2514-22a9-43f2-be86-10b9cada366b" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="d832083d-23e5-47b8-ab97-b9f554f2acb7"
+            name="System" abstractType="#1e74d8b5-2203-4b97-acdb-8f738157a010"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="1e74d8b5-2203-4b97-acdb-8f738157a010" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="485c9641-8c55-4ba4-893a-08ad1bf4bea9" targetElement="#c1091b6a-b983-48dd-8d41-d9443bdc1846"
+              sourceElement="#1e74d8b5-2203-4b97-acdb-8f738157a010"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="1351da93-9872-4251-bcba-6e16bc88f282" targetElement="#d412e424-e5bb-44ce-9a26-00bcb406a3b0"
+          sourceElement="#1a52d585-a722-4e9a-824e-e0992cb45280"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/.project
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ExternalFunctionExchangeItemTransition</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.afm
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_CzvesD2jEe2S3PLqRW1ZAA">
+  <viewpointReferences id="_C0E14D2jEe2S3PLqRW1ZAA" vpId="org.polarsys.capella.core.viewpoint" version="6.0.0"/>
+</metadata:Metadata>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.aird
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.aird
@@ -1,0 +1,1506 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/6.0.0" xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/6.0.0" xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/6.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_CzxT4D2jEe2S3PLqRW1ZAA" selectedViews="_C0N_0D2jEe2S3PLqRW1ZAA _C1tNkD2jEe2S3PLqRW1ZAA _C5VJUD2jEe2S3PLqRW1ZAA _C6j4YD2jEe2S3PLqRW1ZAA _C7AkUD2jEe2S3PLqRW1ZAA _C7S4MD2jEe2S3PLqRW1ZAA _C8Jz0D2jEe2S3PLqRW1ZAA" version="15.0.0.202201261500">
+    <semanticResources>ExternalFunctionExchangeItemTransition.afm</semanticResources>
+    <semanticResources>ExternalFunctionExchangeItemTransition.capella</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C0N_0D2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C1tNkD2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C5VJUD2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C6j4YD2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Fve3ED2jEe2S3PLqRW1ZAA" name="[PAB] Structure" repPath="#_Fvdo8D2jEe2S3PLqRW1ZAA" changeId="1128ecb6-e343-48c1-a6d0-10aad1fb02a1">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_FvgFMz2jEe2S3PLqRW1ZAA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FvgFND2jEe2S3PLqRW1ZAA" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FvgFNT2jEe2S3PLqRW1ZAA" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg" href="ExternalFunctionExchangeItemTransition.capella#2cbb2303-1b52-49da-8511-8ae9d6e9657a"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_tNH-wD2mEe2S3PLqRW1ZAA" name="[PAB] Physical System" repPath="#_tNGwoD2mEe2S3PLqRW1ZAA" changeId="c625a152-9d22-4489-a47b-7bf9146d24d9">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_tNJM4D2mEe2S3PLqRW1ZAA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tNJM4T2mEe2S3PLqRW1ZAA" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tNJM4j2mEe2S3PLqRW1ZAA" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#081c0909-48fa-4249-9f3b-078ed9075470"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C7AkUD2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C7S4MD2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_C8Jz0D2jEe2S3PLqRW1ZAA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_Fvdo8D2jEe2S3PLqRW1ZAA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_FvgFMD2jEe2S3PLqRW1ZAA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_FvgFMT2jEe2S3PLqRW1ZAA" type="Sirius" element="_Fvdo8D2jEe2S3PLqRW1ZAA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_GqdRkD2jEe2S3PLqRW1ZAA" type="2002" element="_GqXyAD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_GqdRkz2jEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_GqdRlD2jEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_OXmjcD2jEe2S3PLqRW1ZAA" type="3007" element="_OXhD4D2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_OXmjcz2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_OXmjdD2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_OXmjdT2jEe2S3PLqRW1ZAA" type="3003" element="_OXhD4T2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_OXmjdj2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OXmjdz2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bX7mMD2jEe2S3PLqRW1ZAA" type="3001" element="_bXtjwD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_bX7mMz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bX7mND2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_bYDiAD2jEe2S3PLqRW1ZAA" type="3005" element="_bXuK0D2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bYDiAT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYDiAj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bX7mMT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bX7mMj2jEe2S3PLqRW1ZAA" x="143" y="40" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_hAYfoD2nEe2S3PLqRW1ZAA" type="3001" element="_hAGy0D2nEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_hAYfoz2nEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_hAYfpD2nEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_hAcKAD2nEe2S3PLqRW1ZAA" type="3005" element="_hAGy0T2nEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_hAcKAT2nEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAcKAj2nEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_hAYfoT2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAYfoj2nEe2S3PLqRW1ZAA" x="143" y="60" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_OXmjcT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OXmjcj2jEe2S3PLqRW1ZAA" x="45" y="44" width="151" height="91"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_O2_OID2jEe2S3PLqRW1ZAA" type="3007" element="_O24gcD2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_O2_OIz2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_O2_OJD2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_O2_OJT2jEe2S3PLqRW1ZAA" type="3003" element="_O25HgD2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_O2_OJj2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O2_OJz2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_fOyjAD2jEe2S3PLqRW1ZAA" type="3001" element="_fOoyBD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_fOyjAz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_fOyjBD2jEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_fO2NYD2jEe2S3PLqRW1ZAA" type="3005" element="_fOpZED2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_fO2NYT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO2NYj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_fOyjAT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fOyjAj2jEe2S3PLqRW1ZAA" x="100" y="83" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_O2_OIT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O2_OIj2jEe2S3PLqRW1ZAA" x="45" y="164" width="151" height="91"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_GqdRlT2jEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_GqdRlj2jEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_GqdRkT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GqdRkj2jEe2S3PLqRW1ZAA" x="190" y="350" width="263" height="283"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_HVPT8D2jEe2S3PLqRW1ZAA" type="2002" element="_HVJ0YD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_HVPT8z2jEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_HVPT9D2jEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_RtEqcD2jEe2S3PLqRW1ZAA" type="3007" element="_Rs_K4D2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_RtEqcz2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_RtEqdD2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_RtEqdT2jEe2S3PLqRW1ZAA" type="3003" element="_Rs_K4T2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_RtEqdj2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RtEqdz2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_bYEJED2jEe2S3PLqRW1ZAA" type="3001" element="_bXycQT2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_bYEJEz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_bYEJFD2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_bYKPsD2jEe2S3PLqRW1ZAA" type="3005" element="_bXycQj2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_bYKPsT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYKPsj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_bYEJET2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYEJEj2jEe2S3PLqRW1ZAA" x="-2" y="20" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_c9l8cD2jEe2S3PLqRW1ZAA" type="3001" element="_c9eAoD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_c9l8cz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_c9l8dD2jEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_c9o_wD2jEe2S3PLqRW1ZAA" type="3005" element="_c9eAoT2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_c9o_wT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9o_wj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_c9l8cT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9l8cj2jEe2S3PLqRW1ZAA" x="100" y="53" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_RtEqcT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RtEqcj2jEe2S3PLqRW1ZAA" x="15" y="34" width="121" height="61"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_V7snAD2jEe2S3PLqRW1ZAA" type="3007" element="_V7nHcD2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_V7snAz2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_V7snBD2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_V7snBT2jEe2S3PLqRW1ZAA" type="3003" element="_V7nHcT2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_V7snBj2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V7snBz2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_c9pm0D2jEe2S3PLqRW1ZAA" type="3001" element="_c9eApD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_c9pm0z2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_c9pm1D2jEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_c9sDED2jEe2S3PLqRW1ZAA" type="3005" element="_c9eApT2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_c9sDET2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9sDEj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_c9pm0T2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9pm0j2jEe2S3PLqRW1ZAA" x="90" y="-2" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_d6AhYD2jEe2S3PLqRW1ZAA" type="3001" element="_d53XcD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_d6AhYz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_d6AhZD2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_d6DksD2jEe2S3PLqRW1ZAA" type="3005" element="_d53-gD2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_d6DksT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6Dksj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_d6AhYT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6AhYj2jEe2S3PLqRW1ZAA" x="113" y="30" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_hAcKAz2nEe2S3PLqRW1ZAA" type="3001" element="_hAHZ4T2nEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_hAcKBj2nEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_hAcKBz2nEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_hAf0YD2nEe2S3PLqRW1ZAA" type="3005" element="_hAHZ4j2nEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_hAf0YT2nEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAf0Yj2nEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_hAcKBD2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAcKBT2nEe2S3PLqRW1ZAA" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_V7snAT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_V7snAj2jEe2S3PLqRW1ZAA" x="55" y="134" width="121" height="51"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_HVPT9T2jEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_HVPT9j2jEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_HVPT8T2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HVPT8j2jEe2S3PLqRW1ZAA" x="660" y="240" width="213" height="213"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_IDoD8D2jEe2S3PLqRW1ZAA" type="2002" element="_IDjLcD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_IDorAD2jEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_IDorAT2jEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_XOAjcD2jEe2S3PLqRW1ZAA" type="3007" element="_XN7D4D2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_XOAjcz2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_XOAjdD2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_XOAjdT2jEe2S3PLqRW1ZAA" type="3003" element="_XN7D4T2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_XOAjdj2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XOAjdz2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_eZaaPD2jEe2S3PLqRW1ZAA" type="3001" element="_eZRQQz2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_eZaaPz2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_eZaaQD2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_eZeEkD2jEe2S3PLqRW1ZAA" type="3005" element="_eZRQRD2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_eZeEkT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZeEkj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_eZaaPT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZaaPj2jEe2S3PLqRW1ZAA" x="133" y="40" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_fO2NYz2jEe2S3PLqRW1ZAA" type="3001" element="_fOoyAD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_fO3bgD2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_fO3bgT2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_fO7F4D2jEe2S3PLqRW1ZAA" type="3005" element="_fOoyAT2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_fO7F4T2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO7F4j2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_fO2NZD2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO2NZT2jEe2S3PLqRW1ZAA" x="-2" y="70" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_XOAjcT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_XOAjcj2jEe2S3PLqRW1ZAA" x="35" y="74" width="141" height="111"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_IDorAj2jEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_IDorAz2jEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_IDoD8T2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IDoD8j2jEe2S3PLqRW1ZAA" x="660" y="580" width="221" height="211"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_MaCDgD2jEe2S3PLqRW1ZAA" type="2002" element="_MZ8j8D2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_MaCDgz2jEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_MaCDhD2jEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_Y1JgYD2jEe2S3PLqRW1ZAA" type="3007" element="_Y1EA0D2jEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_Y1KHcD2jEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Y1KHcT2jEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_Y1KHcj2jEe2S3PLqRW1ZAA" type="3003" element="_Y1En4D2jEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_Y1KHcz2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y1KHdD2jEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_d6Dksz2jEe2S3PLqRW1ZAA" type="3001" element="_d53-gz2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_d6ELwD2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_d6ELwT2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_d6GoAD2jEe2S3PLqRW1ZAA" type="3005" element="_d53-hD2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_d6GoAT2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6GoAj2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_d6DktD2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6DktT2jEe2S3PLqRW1ZAA" x="-2" y="30" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_eZeEkz2jEe2S3PLqRW1ZAA" type="3001" element="_eZQpMD2jEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_eZeElj2jEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_eZeElz2jEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_eZgg0D2jEe2S3PLqRW1ZAA" type="3005" element="_eZRQQD2jEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_eZgg0T2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZgg0j2jEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_eZeElD2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZeElT2jEe2S3PLqRW1ZAA" x="-2" y="80" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Y1JgYT2jEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y1JgYj2jEe2S3PLqRW1ZAA" x="45" y="114" width="151" height="111"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_MaCDhT2jEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_MaCDhj2jEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_MaCDgT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MaCDgj2jEe2S3PLqRW1ZAA" x="1070" y="330" width="273" height="323"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ob1hYD2jEe2S3PLqRW1ZAA" type="2001" element="_obpUID2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ob2IcD2jEe2S3PLqRW1ZAA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ob2IcT2jEe2S3PLqRW1ZAA" x="21" y="2"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob2Icj2jEe2S3PLqRW1ZAA" type="3003" element="_obp7MD2jEe2S3PLqRW1ZAA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ob2Icz2jEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2IdD2jEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ob1hYT2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob1hYj2jEe2S3PLqRW1ZAA" x="900" y="346" width="20" height="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_FvgFMj2jEe2S3PLqRW1ZAA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_bYKPsz2jEe2S3PLqRW1ZAA" type="4001" element="_bXzDUT2jEe2S3PLqRW1ZAA" source="_bX7mMD2jEe2S3PLqRW1ZAA" target="_bYEJED2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_bYKPtz2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYKPuD2jEe2S3PLqRW1ZAA" x="-2" y="-11"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_bYKPuT2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYKPuj2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_bYKPuz2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bYKPvD2jEe2S3PLqRW1ZAA" x="1" y="9"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_bYKPtD2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_bYKPtT2jEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bYKPtj2jEe2S3PLqRW1ZAA" points="[5, -3, -290, 137]$[290, -138, -5, 2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYKPvT2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bYKPvj2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_c9sqID2jEe2S3PLqRW1ZAA" type="4001" element="_c9eAqD2jEe2S3PLqRW1ZAA" source="_c9l8cD2jEe2S3PLqRW1ZAA" target="_c9pm0D2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_c9sqJD2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9sqJT2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_c9sqJj2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9sqJz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_c9sqKD2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_c9sqKT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_c9sqIT2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_c9sqIj2jEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c9sqIz2jEe2S3PLqRW1ZAA" points="[3, 5, -27, -40]$[26, 40, -4, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9sqKj2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c9sqKz2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_d6GoAz2jEe2S3PLqRW1ZAA" type="4001" element="_d53-hz2jEe2S3PLqRW1ZAA" source="_d6AhYD2jEe2S3PLqRW1ZAA" target="_d6Dksz2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_d6HPED2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6HPET2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_d6HPEj2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6HPEz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_d6HPFD2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_d6HPFT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_d6GoBD2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_d6GoBT2jEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_d6GoBj2jEe2S3PLqRW1ZAA" points="[5, 1, -280, -69]$[280, 68, -5, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d6HPFj2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_d6HPFz2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_eZhH4D2jEe2S3PLqRW1ZAA" type="4001" element="_eZR3Uj2jEe2S3PLqRW1ZAA" source="_eZeEkz2jEe2S3PLqRW1ZAA" target="_eZaaPD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_eZhH5D2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZhH5T2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_eZhH5j2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZhH5z2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_eZhH6D2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eZhH6T2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_eZhH4T2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_eZhH4j2jEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eZhH4z2jEe2S3PLqRW1ZAA" points="[-5, 2, 280, -168]$[-280, 167, 5, -3]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eZhH6j2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eZhH6z2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_fO7s8D2jEe2S3PLqRW1ZAA" type="4001" element="_fOpZEz2jEe2S3PLqRW1ZAA" source="_fO2NYz2jEe2S3PLqRW1ZAA" target="_fOyjAD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_fO7s9D2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO7s9T2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_fO7s9j2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO7s9z2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_fO7s-D2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fO7s-T2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_fO7s8T2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_fO7s8j2jEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fO7s8z2jEe2S3PLqRW1ZAA" points="[-5, -2, 353, 125]$[-353, -126, 5, 1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fO7s-j2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fO7s-z2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ob2vgD2jEe2S3PLqRW1ZAA" type="4001" element="_obyeED2jEe2S3PLqRW1ZAA" source="_c9pm0D2jEe2S3PLqRW1ZAA" target="_d6AhYD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ob2vhD2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2vhT2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob2vhj2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2vhz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob2viD2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2viT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ob2vgT2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ob2vgj2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ob2vgz2jEe2S3PLqRW1ZAA" points="[3, 5, -20, -27]$[19, 27, -4, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob2vij2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob2viz2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ob2vjD2jEe2S3PLqRW1ZAA" type="4001" element="_obyeFT2jEe2S3PLqRW1ZAA" source="_d6Dksz2jEe2S3PLqRW1ZAA" target="_eZeEkz2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ob2vkD2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2vkT2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob2vkj2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2vkz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob2vlD2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob2vlT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ob2vjT2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ob2vjj2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ob2vjz2jEe2S3PLqRW1ZAA" points="[0, 5, 0, -45]$[0, 45, 0, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob2vlj2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob2vlz2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ob3WkD2jEe2S3PLqRW1ZAA" type="4001" element="_obyeGj2jEe2S3PLqRW1ZAA" source="_bYEJED2jEe2S3PLqRW1ZAA" target="_c9l8cD2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ob3WlD2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob3WlT2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob3Wlj2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob3Wlz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob3WmD2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob3WmT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ob3WkT2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ob3Wkj2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ob3Wkz2jEe2S3PLqRW1ZAA" points="[5, 1, -97, -32]$[97, 31, -5, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob39oD2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob39oT2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ob39oj2jEe2S3PLqRW1ZAA" type="4001" element="_obzFJD2jEe2S3PLqRW1ZAA" source="_eZaaPD2jEe2S3PLqRW1ZAA" target="_fO2NYz2jEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ob39pj2jEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob39pz2jEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob39qD2jEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob39qT2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ob39qj2jEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ob39qz2jEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ob39oz2jEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ob39pD2jEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ob39pT2jEe2S3PLqRW1ZAA" points="[-5, 1, 130, -29]$[-130, 28, 5, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob39rD2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ob39rT2jEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_hAgbcD2nEe2S3PLqRW1ZAA" type="4001" element="_hAHZ5T2nEe2S3PLqRW1ZAA" source="_hAYfoD2nEe2S3PLqRW1ZAA" target="_hAcKAz2nEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_hAgbdD2nEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAgbdT2nEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_hAgbdj2nEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAgbdz2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_hAgbeD2nEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hAgbeT2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_hAgbcT2nEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_hAgbcj2nEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hAgbcz2nEe2S3PLqRW1ZAA" points="[5, -1, -330, 49]$[330, -50, -5, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hAgbej2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_hAgbez2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Fvk9sD2jEe2S3PLqRW1ZAA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_FvlkwD2jEe2S3PLqRW1ZAA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_GqXyAD2jEe2S3PLqRW1ZAA" name="PC 1">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#4c895a3e-3f5b-4d6c-8f2d-f9d7d1767362"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#4c895a3e-3f5b-4d6c-8f2d-f9d7d1767362"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#1345c718-6b74-4968-a445-3b38da65877d"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_GqXyAT2jEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_OXhD4D2jEe2S3PLqRW1ZAA" name="PhysicalFunction 1" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#e935f18e-6235-442c-8e5d-e280cf493d6e"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#e935f18e-6235-442c-8e5d-e280cf493d6e"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_bXtjwD2jEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_bXzDUT2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#aaa41e95-09cf-473d-b30c-dee08c408b69"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#aaa41e95-09cf-473d-b30c-dee08c408b69"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_bXycQD2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_bXuK0D2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_hAGy0D2nEe2S3PLqRW1ZAA" name="FOP 2" outgoingEdges="_hAHZ5T2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#67e881e6-06ea-4273-9c49-7a56f3a8848d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#67e881e6-06ea-4273-9c49-7a56f3a8848d"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_hAHZ4D2nEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_hAGy0T2nEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_OXhD4T2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_O24gcD2jEe2S3PLqRW1ZAA" name="PhysicalFunction 2" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#972c1a2f-3822-4061-98ca-e9d8b6f62e27"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#972c1a2f-3822-4061-98ca-e9d8b6f62e27"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_fOoyBD2jEe2S3PLqRW1ZAA" name="FIP 1" incomingEdges="_fOpZEz2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#53e0e8dd-540d-4e76-a078-b21e8cbb9e97"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#53e0e8dd-540d-4e76-a078-b21e8cbb9e97"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_fOpZEj2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fOpZED2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_O25HgD2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HVJ0YD2jEe2S3PLqRW1ZAA" name="PC 2">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#e8293646-8f4a-4f13-8f15-aae14b887df4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#e8293646-8f4a-4f13-8f15-aae14b887df4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#2817e3a1-661a-4c35-85bc-119a86d9fc5e"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HVJ0YT2jEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_Rs_K4D2jEe2S3PLqRW1ZAA" name="PhysicalFunction 3" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#26bb97ef-c46c-46cd-91c3-d39007d2dca5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#26bb97ef-c46c-46cd-91c3-d39007d2dca5"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_bXycQT2jEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_obyeGj2jEe2S3PLqRW1ZAA" incomingEdges="_bXzDUT2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#c4b58a5b-7b59-4878-a3b0-98f81d84a460"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#c4b58a5b-7b59-4878-a3b0-98f81d84a460"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_bXzDUD2jEe2S3PLqRW1ZAA"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_bXycQj2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_c9eAoD2jEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_c9eAqD2jEe2S3PLqRW1ZAA" incomingEdges="_obyeGj2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#76efc73d-fb3e-44c6-aa11-313be1ed4e1e"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#76efc73d-fb3e-44c6-aa11-313be1ed4e1e"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_c9eAoz2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_c9eAoT2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Rs_K4T2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_V7nHcD2jEe2S3PLqRW1ZAA" name="PhysicalFunction 4" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#08a1c332-e40a-4914-9f8b-f6b2e470a1d7"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#08a1c332-e40a-4914-9f8b-f6b2e470a1d7"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_c9eApD2jEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_obyeED2jEe2S3PLqRW1ZAA" incomingEdges="_c9eAqD2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#20543c0a-fb02-47c0-89c9-f288431d83b6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#20543c0a-fb02-47c0-89c9-f288431d83b6"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_c9eApz2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_c9eApT2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_d53XcD2jEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_d53-hz2jEe2S3PLqRW1ZAA" incomingEdges="_obyeED2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#20116911-ea74-4033-8245-3d7c09b859fa"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#20116911-ea74-4033-8245-3d7c09b859fa"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_d53-gj2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_d53-gD2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_hAHZ4T2nEe2S3PLqRW1ZAA" name="FIP 2" incomingEdges="_hAHZ5T2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#16345a05-7eb0-47c3-80c6-f128a1029612"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#16345a05-7eb0-47c3-80c6-f128a1029612"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_hAHZ5D2nEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_hAHZ4j2nEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_V7nHcT2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_IDjLcD2jEe2S3PLqRW1ZAA" name="PC 3">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#019eed83-40ee-4eb6-b43e-efc1fb54e94d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#019eed83-40ee-4eb6-b43e-efc1fb54e94d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#f5d9f694-ead3-4889-8eb6-4ebfb2f300a4"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_IDjLcT2jEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_XN7D4D2jEe2S3PLqRW1ZAA" name="PhysicalFunction 5" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#2e7c03d8-2a3a-4df4-a26f-3f0977c4457d"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#2e7c03d8-2a3a-4df4-a26f-3f0977c4457d"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_eZRQQz2jEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_obzFJD2jEe2S3PLqRW1ZAA" incomingEdges="_eZR3Uj2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#9b38b880-8d21-4d07-97a8-e4b04b474160"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#9b38b880-8d21-4d07-97a8-e4b04b474160"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_eZR3UT2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_eZRQRD2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_fOoyAD2jEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_fOpZEz2jEe2S3PLqRW1ZAA" incomingEdges="_obzFJD2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#458d33d6-7c72-41d1-bcdd-cb2432387526"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#458d33d6-7c72-41d1-bcdd-cb2432387526"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_fOoyAz2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_fOoyAT2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_XN7D4T2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_MZ8j8D2jEe2S3PLqRW1ZAA" name="PC 4">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#59a1cea1-110f-446f-ae5c-9248c959f0d6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#59a1cea1-110f-446f-ae5c-9248c959f0d6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#183a5ea4-224b-4ca1-a5e9-e28229897201"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_MZ8j8T2jEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_Y1EA0D2jEe2S3PLqRW1ZAA" name="PhysicalFunction 6" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#5c9e96e2-8a95-49ff-9b01-3a233322534a"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#5c9e96e2-8a95-49ff-9b01-3a233322534a"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_d53-gz2jEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_obyeFT2jEe2S3PLqRW1ZAA" incomingEdges="_d53-hz2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#b8fab683-692d-4f60-971e-c5c34920b0d6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#b8fab683-692d-4f60-971e-c5c34920b0d6"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_d53-hj2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_d53-hD2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_eZQpMD2jEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_eZR3Uj2jEe2S3PLqRW1ZAA" incomingEdges="_obyeFT2jEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#15df1dec-08b7-48e7-97fb-81c4eaa6583a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#15df1dec-08b7-48e7-97fb-81c4eaa6583a"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_eZRQQj2jEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_eZRQQD2jEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Y1En4D2jEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_bXzDUT2jEe2S3PLqRW1ZAA" name="FunctionalExchange 1" sourceNode="_bXtjwD2jEe2S3PLqRW1ZAA" targetNode="_bXycQT2jEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#8fc579e3-3e40-4756-a031-8048b1735111"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#8fc579e3-3e40-4756-a031-8048b1735111"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_bXzDUj2jEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_bXzDUz2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_bXzDVT2jEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_bXzDVD2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_c9eAqD2jEe2S3PLqRW1ZAA" name="FunctionalExchange 2" sourceNode="_c9eAoD2jEe2S3PLqRW1ZAA" targetNode="_c9eApD2jEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#0b85472a-8a4d-44a0-99f2-6cb79e6945ee"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#0b85472a-8a4d-44a0-99f2-6cb79e6945ee"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_c9eAqT2jEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_c9eAqj2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_c9eArD2jEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_c9eAqz2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_d53-hz2jEe2S3PLqRW1ZAA" name="FunctionalExchange 3" sourceNode="_d53XcD2jEe2S3PLqRW1ZAA" targetNode="_d53-gz2jEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#ece2c7e5-af25-439c-a094-8a9cba1aab74"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#ece2c7e5-af25-439c-a094-8a9cba1aab74"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_d53-iD2jEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_d53-iT2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_d53-iz2jEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_d53-ij2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_eZR3Uj2jEe2S3PLqRW1ZAA" name="FunctionalExchange 4" sourceNode="_eZQpMD2jEe2S3PLqRW1ZAA" targetNode="_eZRQQz2jEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#f349c3cc-6cd7-4a5a-9bbb-62280771e9e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#f349c3cc-6cd7-4a5a-9bbb-62280771e9e9"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_eZR3Uz2jEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_eZR3VD2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_eZR3Vj2jEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_eZR3VT2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fOpZEz2jEe2S3PLqRW1ZAA" name="FunctionalExchange 5" sourceNode="_fOoyAD2jEe2S3PLqRW1ZAA" targetNode="_fOoyBD2jEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#c1c0e336-1ed8-412e-832a-50fc89e69031"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#c1c0e336-1ed8-412e-832a-50fc89e69031"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_fOpZFD2jEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_fOpZFT2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_fOpZFz2jEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_fOpZFj2jEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_obpUID2jEe2S3PLqRW1ZAA" name="FunctionalChain 1" width="2" height="2" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_obp7MD2jEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" width="2" height="2" color="24,114,248">
+        <customFeatures>color</customFeatures>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_FunctionalChainEnd']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_FunctionalChainEnd']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_obyeED2jEe2S3PLqRW1ZAA" sourceNode="_c9eApD2jEe2S3PLqRW1ZAA" targetNode="_d53XcD2jEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_obyeET2jEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_obyeEj2jEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_obyeFT2jEe2S3PLqRW1ZAA" sourceNode="_d53-gz2jEe2S3PLqRW1ZAA" targetNode="_eZQpMD2jEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_obyeFj2jEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_obyeFz2jEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_obyeGj2jEe2S3PLqRW1ZAA" sourceNode="_bXycQT2jEe2S3PLqRW1ZAA" targetNode="_c9eAoD2jEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_obzFID2jEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_obzFIT2jEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_obzFJD2jEe2S3PLqRW1ZAA" sourceNode="_eZRQQz2jEe2S3PLqRW1ZAA" targetNode="_fOoyAD2jEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#c5bb3da3-0f29-497d-a531-422d35a7a4e9"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_obzFJT2jEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_obzFJj2jEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_hAHZ5T2nEe2S3PLqRW1ZAA" name="FunctionalExchange 6" sourceNode="_hAGy0D2nEe2S3PLqRW1ZAA" targetNode="_hAHZ4T2nEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#36284978-5a75-4cfe-ae33-91715655a912"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#36284978-5a75-4cfe-ae33-91715655a912"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_hAHZ5j2nEe2S3PLqRW1ZAA" targetArrow="NoDecoration" centered="Both" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_hAHZ5z2nEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_hAHZ6T2nEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_hAHZ6D2nEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Fvdo8T2jEe2S3PLqRW1ZAA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg" href="ExternalFunctionExchangeItemTransition.capella#2cbb2303-1b52-49da-8511-8ae9d6e9657a"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_tNGwoD2mEe2S3PLqRW1ZAA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_tNIl0D2mEe2S3PLqRW1ZAA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_tNIl0T2mEe2S3PLqRW1ZAA" type="Sirius" element="_tNGwoD2mEe2S3PLqRW1ZAA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_ue9aED2mEe2S3PLqRW1ZAA" type="2002" element="_uezCAD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ue9aEz2mEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_ue9aFD2mEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_1lNEAD2mEe2S3PLqRW1ZAA" type="3007" element="_1lCr8D2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_1lNrED2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_1lNrET2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_1lNrEj2mEe2S3PLqRW1ZAA" type="3003" element="_1lCr8T2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_1lNrEz2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1lNrFD2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_7NbQwD2mEe2S3PLqRW1ZAA" type="3001" element="_7NPqkD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_7Nb30D2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_7Nb30T2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_7NgJQD2mEe2S3PLqRW1ZAA" type="3005" element="_7NPqkT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7NgJQT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NgJQj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_7NbQwT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NbQwj2mEe2S3PLqRW1ZAA" x="223" y="30" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_1lNEAT2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1lNEAj2mEe2S3PLqRW1ZAA" x="55" y="54" width="231" height="81"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_2SiEED2mEe2S3PLqRW1ZAA" type="3007" element="_2SXsAD2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_2SiEEz2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_2SiEFD2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_2SiEFT2mEe2S3PLqRW1ZAA" type="3003" element="_2SXsAT2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_2SiEFj2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2SiEFz2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_-bYagD2mEe2S3PLqRW1ZAA" type="3001" element="_-bK_JD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_-bYagz2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-bYahD2mEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_-bbd0D2mEe2S3PLqRW1ZAA" type="3005" element="_-bK_JT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_-bbd0T2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-bbd0j2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_-bYagT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-bYagj2mEe2S3PLqRW1ZAA" x="110" y="103" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_2SiEET2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2SiEEj2mEe2S3PLqRW1ZAA" x="55" y="174" width="231" height="111"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_ue9aFT2mEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_ue9aFj2mEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ue9aET2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ue9aEj2mEe2S3PLqRW1ZAA" x="110" y="300" width="333" height="303"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_vNq6MD2mEe2S3PLqRW1ZAA" type="2002" element="_vNes8D2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_vNq6Mz2mEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_vNq6ND2mEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_3f52ID2mEe2S3PLqRW1ZAA" type="3007" element="_3fu3AD2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_3f52Iz2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3f52JD2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3f52JT2mEe2S3PLqRW1ZAA" type="3003" element="_3fu3AT2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3f52Jj2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3f52Jz2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_7NgJQz2mEe2S3PLqRW1ZAA" type="3001" element="_7NQRoT2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_7NgJRj2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_7NgJRz2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_7NjMkD2mEe2S3PLqRW1ZAA" type="3005" element="_7NQRoj2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7NjMkT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NjMkj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_7NgJRD2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NgJRT2mEe2S3PLqRW1ZAA" x="-2" y="40" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_70oasD2mEe2S3PLqRW1ZAA" type="3001" element="_70ZxMD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_70oasz2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_70oatD2mEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_70sFED2mEe2S3PLqRW1ZAA" type="3005" element="_70ZxMT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_70sFET2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70sFEj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_70oasT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70oasj2mEe2S3PLqRW1ZAA" x="180" y="73" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3f52IT2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3f52Ij2mEe2S3PLqRW1ZAA" x="35" y="34" width="251" height="81"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3wSbgD2mEe2S3PLqRW1ZAA" type="3007" element="_3wIqgD2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_3wTCkD2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3wTCkT2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3wTCkj2mEe2S3PLqRW1ZAA" type="3003" element="_3wIqgT2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3wTCkz2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wTClD2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_70sFEz2mEe2S3PLqRW1ZAA" type="3001" element="_70aYQD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_70sFFj2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_70sFFz2mEe2S3PLqRW1ZAA" x="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_70vvcD2mEe2S3PLqRW1ZAA" type="3005" element="_70aYQT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_70vvcT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70vvcj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_70sFFD2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70sFFT2mEe2S3PLqRW1ZAA" x="170" y="-2" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_8eM8ID2mEe2S3PLqRW1ZAA" type="3001" element="_8d9EgD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_8eM8Iz2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_8eM8JD2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_8eP_cD2mEe2S3PLqRW1ZAA" type="3005" element="_8d9rkD2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_8eP_cT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eP_cj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_8eM8IT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eM8Ij2mEe2S3PLqRW1ZAA" x="233" y="50" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3wSbgT2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3wSbgj2mEe2S3PLqRW1ZAA" x="45" y="154" width="241" height="81"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_vNq6NT2mEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_vNq6Nj2mEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_vNq6MT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vNq6Mj2mEe2S3PLqRW1ZAA" x="610" y="30" width="333" height="273"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_v1BOED2mEe2S3PLqRW1ZAA" type="2002" element="_v022AD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_v1BOEz2mEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_v1BOFD2mEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_4RZkgD2mEe2S3PLqRW1ZAA" type="3007" element="_4RPMcD2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_4RZkgz2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_4RZkhD2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_4RZkhT2mEe2S3PLqRW1ZAA" type="3003" element="_4RPMcT2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_4RZkhj2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4RZkhz2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_9jdUAD2mEe2S3PLqRW1ZAA" type="3001" element="_9jP4oD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_9jdUAz2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_9jdUBD2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_9jgXUD2mEe2S3PLqRW1ZAA" type="3005" element="_9jP4oT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_9jgXUT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jgXUj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_9jdUAT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jdUAj2mEe2S3PLqRW1ZAA" x="173" y="60" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_-bcE4D2mEe2S3PLqRW1ZAA" type="3001" element="_-bK_ID2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_-bcE4z2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-bcE5D2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_-behID2mEe2S3PLqRW1ZAA" type="3005" element="_-bK_IT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_-behIT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-behIj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_-bcE4T2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-bcE4j2mEe2S3PLqRW1ZAA" x="-2" y="80" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_4RZkgT2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4RZkgj2mEe2S3PLqRW1ZAA" x="65" y="84" width="181" height="131"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_v1BOFT2mEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_v1BOFj2mEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_v1BOET2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_v1BOEj2mEe2S3PLqRW1ZAA" x="600" y="560" width="333" height="293"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ySQskD2mEe2S3PLqRW1ZAA" type="2002" element="_ySGUgD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_ySQskz2mEe2S3PLqRW1ZAA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_ySQslD2mEe2S3PLqRW1ZAA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_38pcgD2mEe2S3PLqRW1ZAA" type="3007" element="_38fEcD2mEe2S3PLqRW1ZAA">
+              <children xmi:type="notation:Node" xmi:id="_38pcgz2mEe2S3PLqRW1ZAA" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_38pchD2mEe2S3PLqRW1ZAA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_38pchT2mEe2S3PLqRW1ZAA" type="3003" element="_38fEcT2mEe2S3PLqRW1ZAA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_38pchj2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_38pchz2mEe2S3PLqRW1ZAA"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_8eP_cz2mEe2S3PLqRW1ZAA" type="3001" element="_8d9rkz2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_8eQmgD2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_8eQmgT2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_8eTCwD2mEe2S3PLqRW1ZAA" type="3005" element="_8d9rlD2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_8eTCwT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eTCwj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_8eP_dD2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eP_dT2mEe2S3PLqRW1ZAA" x="-2" y="40" width="10" height="10"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_9jgXUz2mEe2S3PLqRW1ZAA" type="3001" element="_9jPRkD2mEe2S3PLqRW1ZAA">
+                <children xmi:type="notation:Node" xmi:id="_9jgXVj2mEe2S3PLqRW1ZAA" visible="false" type="5001">
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_9jgXVz2mEe2S3PLqRW1ZAA" y="11"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_9jjaoD2mEe2S3PLqRW1ZAA" type="3005" element="_9jPRkT2mEe2S3PLqRW1ZAA">
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_9jjaoT2mEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jjaoj2mEe2S3PLqRW1ZAA"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_9jgXVD2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jgXVT2mEe2S3PLqRW1ZAA" x="-2" y="80" width="10" height="10"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_38pcgT2mEe2S3PLqRW1ZAA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_38pcgj2mEe2S3PLqRW1ZAA" x="85" y="114" width="191" height="101"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_ySQslT2mEe2S3PLqRW1ZAA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_ySQslj2mEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ySQskT2mEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ySQskj2mEe2S3PLqRW1ZAA" x="1060" y="280" width="363" height="323"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_CUO7YD2nEe2S3PLqRW1ZAA" type="2001" element="_CT_DwD2nEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_CUO7Yz2nEe2S3PLqRW1ZAA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_CUO7ZD2nEe2S3PLqRW1ZAA" x="-46" y="21"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUO7ZT2nEe2S3PLqRW1ZAA" type="3003" element="_CT_DwT2nEe2S3PLqRW1ZAA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_CUO7Zj2nEe2S3PLqRW1ZAA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUO7Zz2nEe2S3PLqRW1ZAA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_CUO7YT2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUO7Yj2nEe2S3PLqRW1ZAA" x="1130" y="680" width="20" height="20"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_tNIl0j2mEe2S3PLqRW1ZAA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_7NjMkz2mEe2S3PLqRW1ZAA" type="4001" element="_7NQRpT2mEe2S3PLqRW1ZAA" source="_7NbQwD2mEe2S3PLqRW1ZAA" target="_7NgJQz2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_7NjzoD2mEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NjzoT2mEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7Njzoj2mEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7Njzoz2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7NjzpD2mEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7NjzpT2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7NjMlD2mEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7NjMlT2mEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7NjMlj2mEe2S3PLqRW1ZAA" points="[4, -5, -251, 275]$[250, -275, -5, 5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Njzpj2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7Njzpz2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_70vvcz2mEe2S3PLqRW1ZAA" type="4001" element="_70aYRD2mEe2S3PLqRW1ZAA" source="_70oasD2mEe2S3PLqRW1ZAA" target="_70sFEz2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_70vvdz2mEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70vveD2mEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_70wWgD2mEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70wWgT2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_70wWgj2mEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_70wWgz2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_70vvdD2mEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_70vvdT2mEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_70vvdj2mEe2S3PLqRW1ZAA" points="[0, 5, 0, -40]$[0, 40, 0, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_70wWhD2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_70wWhT2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_8eTCwz2mEe2S3PLqRW1ZAA" type="4001" element="_8d-Soj2mEe2S3PLqRW1ZAA" source="_8eM8ID2mEe2S3PLqRW1ZAA" target="_8eP_cz2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_8eTp0D2mEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eTp0T2mEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_8eTp0j2mEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eTp0z2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_8eTp1D2mEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8eTp1T2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_8eTCxD2mEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_8eTCxT2mEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8eTCxj2mEe2S3PLqRW1ZAA" points="[5, 3, -250, -197]$[250, 196, -5, -4]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8eTp1j2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8eTp1z2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_9jjaoz2mEe2S3PLqRW1ZAA" type="4001" element="_9jP4pD2mEe2S3PLqRW1ZAA" source="_9jgXUz2mEe2S3PLqRW1ZAA" target="_9jdUAD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_9jjapz2mEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jjaqD2mEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_9jjaqT2mEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jjaqj2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_9jjaqz2mEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9jjarD2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_9jjapD2mEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_9jjapT2mEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9jjapj2mEe2S3PLqRW1ZAA" points="[-5, 3, 300, -227]$[-300, 226, 5, -4]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jjarT2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9jjarj2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_-behIz2mEe2S3PLqRW1ZAA" type="4001" element="_-bK_KD2mEe2S3PLqRW1ZAA" source="_-bcE4D2mEe2S3PLqRW1ZAA" target="_-bYagD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_-behJz2mEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-behKD2mEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_-behKT2mEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-behKj2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_-behKz2mEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-behLD2mEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_-behJD2mEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_-behJT2mEe2S3PLqRW1ZAA" fontColor="16777215" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-behJj2mEe2S3PLqRW1ZAA" points="[-5, -2, 383, 145]$[-383, -146, 5, 1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-behLT2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-behLj2mEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_CUPicD2nEe2S3PLqRW1ZAA" type="4001" element="_CUFxcD2nEe2S3PLqRW1ZAA" source="_9jdUAD2mEe2S3PLqRW1ZAA" target="_-bcE4D2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_CUPidD2nEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPidT2nEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUPidj2nEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPidz2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUPieD2nEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPieT2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_CUPicT2nEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_CUPicj2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CUPicz2nEe2S3PLqRW1ZAA" points="[-5, 0, 170, -20]$[-170, 19, 5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUPiej2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUPiez2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_CUPifD2nEe2S3PLqRW1ZAA" type="4001" element="_CUGYhD2nEe2S3PLqRW1ZAA" source="_7NgJQz2mEe2S3PLqRW1ZAA" target="_70oasD2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_CUPigD2nEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPigT2nEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUPigj2nEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPigz2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUPihD2nEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPihT2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_CUPifT2nEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_CUPifj2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CUPifz2nEe2S3PLqRW1ZAA" points="[5, 0, -177, -33]$[177, 32, -5, -1]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUPihj2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUPihz2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_CUPiiD2nEe2S3PLqRW1ZAA" type="4001" element="_CUGYiT2nEe2S3PLqRW1ZAA" source="_70sFEz2mEe2S3PLqRW1ZAA" target="_8eM8ID2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_CUPijD2nEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUPijT2nEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUQJgD2nEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUQJgT2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUQJgj2nEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUQJgz2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_CUPiiT2nEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_CUPiij2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CUPiiz2nEe2S3PLqRW1ZAA" points="[5, 4, -58, -48]$[58, 47, -5, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUQJhD2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUQJhT2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_CUQJhj2nEe2S3PLqRW1ZAA" type="4001" element="_CUGYjj2nEe2S3PLqRW1ZAA" source="_8eP_cz2mEe2S3PLqRW1ZAA" target="_9jgXUz2mEe2S3PLqRW1ZAA">
+          <children xmi:type="notation:Node" xmi:id="_CUQJij2nEe2S3PLqRW1ZAA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUQJiz2nEe2S3PLqRW1ZAA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUQJjD2nEe2S3PLqRW1ZAA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUQJjT2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_CUQJjj2nEe2S3PLqRW1ZAA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CUQJjz2nEe2S3PLqRW1ZAA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_CUQJhz2nEe2S3PLqRW1ZAA" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_CUQJiD2nEe2S3PLqRW1ZAA" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CUQJiT2nEe2S3PLqRW1ZAA" points="[0, 5, 0, -35]$[0, 35, 0, -5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUQJkD2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CUQJkT2nEe2S3PLqRW1ZAA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_tNLCED2mEe2S3PLqRW1ZAA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_tNLCET2mEe2S3PLqRW1ZAA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_uezCAD2mEe2S3PLqRW1ZAA" name="PC 1">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#9a4b4604-e6a1-4c7a-8a41-568806b8011b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#9a4b4604-e6a1-4c7a-8a41-568806b8011b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#3d5c5246-6da4-4a4d-94e3-09c2fdba5b2d"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_uezCAT2mEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_1lCr8D2mEe2S3PLqRW1ZAA" name="PhysicalFunction 1" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#c06a4a94-e4bd-43a8-9e46-9b072a76ed43"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#c06a4a94-e4bd-43a8-9e46-9b072a76ed43"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_7NPqkD2mEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_7NQRpT2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#9a6838bb-78b5-4a14-a08c-e9506aeced19"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#9a6838bb-78b5-4a14-a08c-e9506aeced19"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_7NQRoD2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_7NPqkT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_1lCr8T2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_2SXsAD2mEe2S3PLqRW1ZAA" name="PhysicalFunction 2" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#0fe91acb-d03a-4586-bf84-338a911c0304"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#0fe91acb-d03a-4586-bf84-338a911c0304"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_-bK_JD2mEe2S3PLqRW1ZAA" name="FIP 1" incomingEdges="_-bK_KD2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#12534fb3-618d-42f2-b9ae-19ffdea6cbff"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#12534fb3-618d-42f2-b9ae-19ffdea6cbff"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_-bK_Jz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_-bK_JT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_2SXsAT2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_vNes8D2mEe2S3PLqRW1ZAA" name="PC 2">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#34c2ab21-f649-421a-a673-e6817c2b3202"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#34c2ab21-f649-421a-a673-e6817c2b3202"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#ddfc5fe8-08aa-457c-8835-599884e5e328"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_vNfUAD2mEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_3fu3AD2mEe2S3PLqRW1ZAA" name="PhysicalFunction 3" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#d081995f-5d65-494f-9260-bd6e083a9dba"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#d081995f-5d65-494f-9260-bd6e083a9dba"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_7NQRoT2mEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_CUGYhD2nEe2S3PLqRW1ZAA" incomingEdges="_7NQRpT2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#dc018752-ebcd-46f2-b091-0e6123bd125a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#dc018752-ebcd-46f2-b091-0e6123bd125a"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_7NQRpD2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_7NQRoj2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_70ZxMD2mEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_70aYRD2mEe2S3PLqRW1ZAA" incomingEdges="_CUGYhD2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#cb960bae-a98f-47f6-9f48-0280585b4508"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#cb960bae-a98f-47f6-9f48-0280585b4508"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_70ZxMz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_70ZxMT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3fu3AT2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_3wIqgD2mEe2S3PLqRW1ZAA" name="PhysicalFunction 4" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#23398404-4514-474a-99a1-9912bf74ddb8"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#23398404-4514-474a-99a1-9912bf74ddb8"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_70aYQD2mEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_CUGYiT2nEe2S3PLqRW1ZAA" incomingEdges="_70aYRD2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#d9699fad-0420-413d-8b79-dacb7a088b03"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#d9699fad-0420-413d-8b79-dacb7a088b03"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_70aYQz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_70aYQT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_8d9EgD2mEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_8d-Soj2mEe2S3PLqRW1ZAA" incomingEdges="_CUGYiT2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#2c61db88-001e-47df-9983-df184c4f5849"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#2c61db88-001e-47df-9983-df184c4f5849"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_8d9rkj2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_8d9rkD2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_3wIqgT2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_v022AD2mEe2S3PLqRW1ZAA" name="PC 3">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#c1eced85-cb5b-40cc-ad03-5d151cfa9313"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#c1eced85-cb5b-40cc-ad03-5d151cfa9313"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#509bc652-5123-4cf5-b985-1fa518cc1c22"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_v022AT2mEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_4RPMcD2mEe2S3PLqRW1ZAA" name="PhysicalFunction 6" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#feb96f1c-4f45-4e76-8ab1-c21c7b5cb1bb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#feb96f1c-4f45-4e76-8ab1-c21c7b5cb1bb"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_9jP4oD2mEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_CUFxcD2nEe2S3PLqRW1ZAA" incomingEdges="_9jP4pD2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#40e733b2-b197-4e8b-ae86-03087c0de781"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#40e733b2-b197-4e8b-ae86-03087c0de781"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_9jP4oz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_9jP4oT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_-bK_ID2mEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_-bK_KD2mEe2S3PLqRW1ZAA" incomingEdges="_CUFxcD2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#e9f05f79-483f-4682-bde7-5e4ace6eae8e"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#e9f05f79-483f-4682-bde7-5e4ace6eae8e"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_-bK_Iz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_-bK_IT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_4RPMcT2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ySGUgD2mEe2S3PLqRW1ZAA" name="PC 4">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#9aa291d3-04cc-47a4-9db8-86877680df44"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="ExternalFunctionExchangeItemTransition.capella#9aa291d3-04cc-47a4-9db8-86877680df44"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#48379684-77bc-46ab-8f0c-5c619acb52d1"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ySGUgT2mEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_38fEcD2mEe2S3PLqRW1ZAA" name="PhysicalFunction 5" width="5" height="5" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#36d8b665-b1c6-46d4-af4e-a37295fc844f"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="ExternalFunctionExchangeItemTransition.capella#36d8b665-b1c6-46d4-af4e-a37295fc844f"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_8d9rkz2mEe2S3PLqRW1ZAA" name="FIP 1" outgoingEdges="_CUGYjj2nEe2S3PLqRW1ZAA" incomingEdges="_8d-Soj2mEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#a91e19cf-77b5-4805-89c6-4b3ec0ef3d6b"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionInputPort" href="ExternalFunctionExchangeItemTransition.capella#a91e19cf-77b5-4805-89c6-4b3ec0ef3d6b"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_8d-SoT2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_8d9rlD2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionInputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_9jPRkD2mEe2S3PLqRW1ZAA" name="FOP 1" outgoingEdges="_9jP4pD2mEe2S3PLqRW1ZAA" incomingEdges="_CUGYjj2nEe2S3PLqRW1ZAA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#bd850414-c364-4d86-a01f-38d6725af4e8"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort" href="ExternalFunctionExchangeItemTransition.capella#bd850414-c364-4d86-a01f-38d6725af4e8"/>
+          <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_9jPRkz2mEe2S3PLqRW1ZAA"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_9jPRkT2mEe2S3PLqRW1ZAA" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/FunctionOutputPort.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@borderedNodeMappings[name='PAB_Pin']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:Square" uid="_38fEcT2mEe2S3PLqRW1ZAA" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_PhysicalFunction']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7NQRpT2mEe2S3PLqRW1ZAA" name="FunctionalExchange 1" sourceNode="_7NPqkD2mEe2S3PLqRW1ZAA" targetNode="_7NQRoT2mEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#d8b896c0-34b8-4161-bb71-b55c34749b13"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#d8b896c0-34b8-4161-bb71-b55c34749b13"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_7NQRpj2mEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_7NQRpz2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_7NQRqT2mEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_7NQRqD2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_70aYRD2mEe2S3PLqRW1ZAA" name="FunctionalExchange 2" sourceNode="_70ZxMD2mEe2S3PLqRW1ZAA" targetNode="_70aYQD2mEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#f7d34d23-8f17-44fb-9e46-7ae195e36332"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#f7d34d23-8f17-44fb-9e46-7ae195e36332"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_70aYRT2mEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_70aYRj2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_70aYSD2mEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_70aYRz2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_8d-Soj2mEe2S3PLqRW1ZAA" name="FunctionalExchange 3" sourceNode="_8d9EgD2mEe2S3PLqRW1ZAA" targetNode="_8d9rkz2mEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#e5c78948-2800-4829-abe4-6c1e17810209"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#e5c78948-2800-4829-abe4-6c1e17810209"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_8d-Soz2mEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_8d-SpD2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_8d-Spj2mEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_8d-SpT2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_9jP4pD2mEe2S3PLqRW1ZAA" name="FunctionalExchange 4" sourceNode="_9jPRkD2mEe2S3PLqRW1ZAA" targetNode="_9jP4oD2mEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#049d4262-c81a-4ad1-a660-bf7278a62f76"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#049d4262-c81a-4ad1-a660-bf7278a62f76"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_9jP4pT2mEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_9jP4pj2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_9jP4qD2mEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_9jP4pz2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_-bK_KD2mEe2S3PLqRW1ZAA" name="FunctionalExchange 5" sourceNode="_-bK_ID2mEe2S3PLqRW1ZAA" targetNode="_-bK_JD2mEe2S3PLqRW1ZAA" beginLabel="." endLabel=".">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#3dafb704-85b8-405a-a60b-503c7ff58682"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="ExternalFunctionExchangeItemTransition.capella#3dafb704-85b8-405a-a60b-503c7ff58682"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_-bK_KT2mEe2S3PLqRW1ZAA" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']/@conditionnalStyles.0/@style"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_-bK_Kj2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_-bK_LD2mEe2S3PLqRW1ZAA" labelColor="9,92,46"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_-bK_Kz2mEe2S3PLqRW1ZAA" labelColor="255,255,255"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_FunctionExchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_CT_DwD2nEe2S3PLqRW1ZAA" name="FunctionalChain 1" width="2" height="2" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_CT_DwT2nEe2S3PLqRW1ZAA" borderSize="1" borderSizeComputationExpression="1" width="2" height="2" color="24,114,248">
+        <customFeatures>color</customFeatures>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_FunctionalChainEnd']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='PAB_FunctionalChainEnd']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_CUFxcD2nEe2S3PLqRW1ZAA" sourceNode="_9jP4oD2mEe2S3PLqRW1ZAA" targetNode="_-bK_ID2mEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_CUGYgD2nEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_CUGYgT2nEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_CUGYhD2nEe2S3PLqRW1ZAA" sourceNode="_7NQRoT2mEe2S3PLqRW1ZAA" targetNode="_70ZxMD2mEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_CUGYhT2nEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_CUGYhj2nEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_CUGYiT2nEe2S3PLqRW1ZAA" sourceNode="_70aYQD2mEe2S3PLqRW1ZAA" targetNode="_8d9EgD2mEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_CUGYij2nEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_CUGYiz2nEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_CUGYjj2nEe2S3PLqRW1ZAA" sourceNode="_8d9rkz2mEe2S3PLqRW1ZAA" targetNode="_9jPRkD2mEe2S3PLqRW1ZAA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="ExternalFunctionExchangeItemTransition.capella#725fde1b-8bbb-4c9d-873c-140aacd7b0d4"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_CUGYjz2nEe2S3PLqRW1ZAA" targetArrow="InputFillClosedArrow" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_CUGYkD2nEe2S3PLqRW1ZAA" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='PAB_InternLink']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedfunctional.chains.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.overlappedphysical.paths.label.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_tNGwoT2mEe2S3PLqRW1ZAA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="ExternalFunctionExchangeItemTransition.capella#081c0909-48fa-4249-9f3b-078ed9075470"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.capella
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/model/ExternalFunctionExchangeItemTransition/ExternalFunctionExchangeItemTransition.capella
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_6.0.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/6.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/6.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/6.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/6.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/6.0.0"
+    id="172cdf95-e027-4f08-a948-2607ecf36db1"
+    name="ExternalFunctionExchangeItemTransition">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="241a57b6-b70c-40da-a967-a276ddff509a"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="a17f2ad5-7a08-4764-83ef-93fa50e99e8b" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="d881c516-d5e0-465d-853c-bbb3197c9491" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="0b2cfd78-a2e8-4d7e-b430-02a0124be480" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="80bfd7cc-02c9-48ca-9142-2353000c15dd" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="9fdd95b6-2832-4e3e-8f9e-6942286176ad" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="ecc378b8-fcfc-446b-95cd-c5a8fb8d1af1" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="9d2471c6-0b17-4cb6-9ec9-438a25302773" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="23abfe57-98b9-4c8e-8dab-87fcf4835c0c"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="a1d400dd-2473-41ac-b23e-a788d877a88d" name="ExternalFunctionExchangeItemTransitionned">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="cd7b367d-76ba-4720-bd21-d9682f676e7d" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="5532b167-da1d-47f3-804e-de976fdb1fa8" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="2f0c01fa-b783-4619-8be4-46a45e94ad14" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="fb0c4a9b-6908-4273-a581-b0375b2ca692" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="98cc1eaa-7d78-455c-9932-90958c59f41b" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="3c43bd7e-a88f-4e86-a05b-d1f4dbec7ee1" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="5b50c449-a401-4adc-94f3-b40be967141c"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="44895692-4c46-4978-99dc-4c5426637573"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="cf3e2680-93fb-4a64-9095-9acb7553581f" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="7e1113e4-bf6f-4a7e-846b-015a63cb0165" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="93e529a8-2edf-4ab9-acaa-86c8335446d7" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="950a361c-c27a-4899-ace3-f064a968c04f" targetElement="#2f0c01fa-b783-4619-8be4-46a45e94ad14"
+              sourceElement="#93e529a8-2edf-4ab9-acaa-86c8335446d7"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="69f00731-5f2a-45cf-9ced-0c4109c49570" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="3d0888fa-0745-4f01-9dae-6e9e66ce52c8" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="8ad02e90-c429-4780-9ea7-b19f94007eea" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="d26d8109-95e2-4def-9d0d-58f07a272f27" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="fde7e502-2789-4981-8b30-2a19dc264383" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="2b95f078-5244-439f-bd55-245c7b2b0ffb" name="True" abstractType="#fde7e502-2789-4981-8b30-2a19dc264383"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="1da499c4-5974-4fd1-b9e1-40665a59e3fe" name="False" abstractType="#fde7e502-2789-4981-8b30-2a19dc264383"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="c1dbdc36-2463-4f8e-8799-80fff1fcbacd" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="7c730f3e-0a74-49c5-a30a-c07cfa6f69be" name="" abstractType="#c1dbdc36-2463-4f8e-8799-80fff1fcbacd"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="64bd3a63-0025-4fd9-98ca-2af80560285e" name="" abstractType="#c1dbdc36-2463-4f8e-8799-80fff1fcbacd"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="11bde62b-8f1e-4596-95f8-a5d8b8519914" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="23a9caa0-cdb4-4229-bff0-fdce6e86b817" name="" abstractType="#e4bbdab0-50b4-49fd-a269-00929f0d044a"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="e72553eb-e4f9-40e6-b32b-6ba89b6738e2" name="" abstractType="#e4bbdab0-50b4-49fd-a269-00929f0d044a"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="c2c97f18-09d1-48aa-a686-e37c1d54a0c2" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="dd21152d-f521-4c44-9e82-b62d9c062485" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="bf25e559-0d43-4429-836b-507146089368" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="824c9dbd-9ce5-4dff-942f-f592363efc4a" name="" abstractType="#bf25e559-0d43-4429-836b-507146089368"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="7b9cc83f-ccdd-430a-a707-7914e88ba5a0" abstractType="#bf25e559-0d43-4429-836b-507146089368"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="4008f3a5-948e-4107-96c1-da12f0775e76" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="8ac409cb-f124-420e-afa7-e485723176f7" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="88cfce88-3970-40b0-9381-d3babc7c18f9" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="9431d11a-1dea-4726-8691-ff00147bd59b" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="ee409a35-d655-4128-b026-055057ae62c2" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="02274f94-6568-4c6b-938a-84735a30614d" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="fb1225fc-17d5-4d6c-b521-36bb9f8904b5" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="87181aa3-7a34-49f9-b855-eb2f30afa222" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="8f2a6fc3-7130-4de5-bf5c-7ca06d9b5212" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="07c22f3d-7c54-4e34-8dfd-08bd847d811a" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="4f439c3e-2ef1-4459-bd39-ba418b364fd9" name="" abstractType="#07c22f3d-7c54-4e34-8dfd-08bd847d811a"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="e4bbdab0-50b4-49fd-a269-00929f0d044a" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="c9034b97-5cab-4901-857b-c0f627f7bfea" name="" abstractType="#e4bbdab0-50b4-49fd-a269-00929f0d044a"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="fb49dee6-92a1-4a75-937a-90072f45a8c8" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="7af5bba2-900f-42c1-8f9a-c1b06a50c7e8" name="" abstractType="#fb49dee6-92a1-4a75-937a-90072f45a8c8"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="20691b70-f2d1-4ffd-8969-35fd0368675b" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="8bce45de-bb46-4669-82f0-9af79ae5316a" name="" abstractType="#20691b70-f2d1-4ffd-8969-35fd0368675b"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="c2636cc9-5bb0-4614-ab27-35eb0ea7d062" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="65220c25-ef8d-4e61-99ea-662a644fddef"
+            name="System" abstractType="#a3424a68-ae93-4e6c-84a0-66a431ef9b9c"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="a3424a68-ae93-4e6c-84a0-66a431ef9b9c" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="aa7ecf9b-eeec-475c-94f4-87fc20aa7547" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="2b6b7543-07b4-43ea-8099-83c06d9fd6f0" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="a69612dd-4fee-40e3-a0e6-a4ec43c6d858"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="2a903939-3d92-4bfc-bd71-ccb46e62246d" targetElement="#cd7b367d-76ba-4720-bd21-d9682f676e7d"
+          sourceElement="#cf3e2680-93fb-4a64-9095-9acb7553581f"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="ad28d6dc-4037-4b17-9fe0-801c562f9cd3" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="c64ce70d-a364-4c76-8496-5c04f5ed02f5" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="32f2d4ac-0fa3-4953-98ab-2449037866d0" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="ebc94e89-b47e-43f1-b36e-fe49e017cfca" targetElement="#93e529a8-2edf-4ab9-acaa-86c8335446d7"
+              sourceElement="#32f2d4ac-0fa3-4953-98ab-2449037866d0"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="a986d0f3-91f3-470a-8af1-91f2636606e0" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="795ffbc4-e160-40ee-b9fd-fc0b043e4074" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="2e7859ff-457d-4a49-8288-4b24aa6931f4" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="74d2660f-5fa6-4ccd-9dd7-c80499994775" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="a8c84eab-ac75-4b83-b479-2d91b3f29bf0"
+            name="Logical System" abstractType="#09082358-e0a0-49a6-b44f-98775424c4af"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="09082358-e0a0-49a6-b44f-98775424c4af" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="40d386f7-f538-4683-aa6f-36aa2156898e" targetElement="#a3424a68-ae93-4e6c-84a0-66a431ef9b9c"
+              sourceElement="#09082358-e0a0-49a6-b44f-98775424c4af"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="8d932bc8-9cd8-4031-8a5e-fb83be71e501" targetElement="#cf3e2680-93fb-4a64-9095-9acb7553581f"
+          sourceElement="#ad28d6dc-4037-4b17-9fe0-801c562f9cd3"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="c409f227-d1c9-47eb-bb0a-f7fcfb42aaee" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="6948c856-ca3f-41d2-a464-53437352755d" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="ebb83cd0-ce64-4800-bb46-bf66e6535b28" name="Root Physical Function">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="c5bb3da3-0f29-497d-a531-422d35a7a4e9" name="FunctionalChain 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="78be1d7e-c65e-4b80-98f8-657e6115d000" involved="#8fc579e3-3e40-4756-a031-8048b1735111"
+                source="#1f255ffa-7674-4a1d-8c4e-276e3d58f43d" target="#527a71bd-957f-49c4-b88e-519261e42687"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="527a71bd-957f-49c4-b88e-519261e42687" involved="#26bb97ef-c46c-46cd-91c3-d39007d2dca5"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="1f255ffa-7674-4a1d-8c4e-276e3d58f43d" involved="#e935f18e-6235-442c-8e5d-e280cf493d6e"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="38f8e75a-17ec-49ff-9f54-cbd7f11674f4" involved="#0b85472a-8a4d-44a0-99f2-6cb79e6945ee"
+                source="#527a71bd-957f-49c4-b88e-519261e42687" target="#e54776a3-1b5b-4b2a-9f2a-3246e7b0f8f5"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="e54776a3-1b5b-4b2a-9f2a-3246e7b0f8f5" involved="#08a1c332-e40a-4914-9f8b-f6b2e470a1d7"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="a9c2517e-1613-47af-a03e-52f38d8ac378" involved="#ece2c7e5-af25-439c-a094-8a9cba1aab74"
+                source="#e54776a3-1b5b-4b2a-9f2a-3246e7b0f8f5" target="#2b3910f6-2096-45ab-9be9-3ae08f45bbe8"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="2b3910f6-2096-45ab-9be9-3ae08f45bbe8" involved="#5c9e96e2-8a95-49ff-9b01-3a233322534a"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="69848d5b-af92-4c2b-81be-d5ff4881a89a" involved="#f349c3cc-6cd7-4a5a-9bbb-62280771e9e9"
+                source="#2b3910f6-2096-45ab-9be9-3ae08f45bbe8" target="#2896cbc0-b166-4b08-8d21-7d2cd9b6796e"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="2896cbc0-b166-4b08-8d21-7d2cd9b6796e" involved="#2e7c03d8-2a3a-4df4-a26f-3f0977c4457d"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="4338b0b2-d759-411c-9046-64d75857864e" involved="#c1c0e336-1ed8-412e-832a-50fc89e69031"
+                source="#2896cbc0-b166-4b08-8d21-7d2cd9b6796e" target="#885012d9-380e-49c6-8ab3-c3ef2813cad7"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="885012d9-380e-49c6-8ab3-c3ef2813cad7" involved="#972c1a2f-3822-4061-98ca-e9d8b6f62e27"/>
+          </ownedFunctionalChains>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="e935f18e-6235-442c-8e5d-e280cf493d6e" name="PhysicalFunction 1">
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="aaa41e95-09cf-473d-b30c-dee08c408b69" name="FOP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="67e881e6-06ea-4273-9c49-7a56f3a8848d" name="FOP 2"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="972c1a2f-3822-4061-98ca-e9d8b6f62e27" name="PhysicalFunction 2">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="53e0e8dd-540d-4e76-a078-b21e8cbb9e97" name="FIP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="26bb97ef-c46c-46cd-91c3-d39007d2dca5" name="PhysicalFunction 3">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="c4b58a5b-7b59-4878-a3b0-98f81d84a460" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="76efc73d-fb3e-44c6-aa11-313be1ed4e1e" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="08a1c332-e40a-4914-9f8b-f6b2e470a1d7" name="PhysicalFunction 4">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="20543c0a-fb02-47c0-89c9-f288431d83b6" name="FIP 1"/>
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="16345a05-7eb0-47c3-80c6-f128a1029612" name="FIP 2"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="20116911-ea74-4033-8245-3d7c09b859fa" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="2e7c03d8-2a3a-4df4-a26f-3f0977c4457d" name="PhysicalFunction 5">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="9b38b880-8d21-4d07-97a8-e4b04b474160" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="458d33d6-7c72-41d1-bcdd-cb2432387526" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="5c9e96e2-8a95-49ff-9b01-3a233322534a" name="PhysicalFunction 6">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="b8fab683-692d-4f60-971e-c5c34920b0d6" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="15df1dec-08b7-48e7-97fb-81c4eaa6583a" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="209cf9c6-e2df-471d-ad54-add22d9dca43" targetElement="#32f2d4ac-0fa3-4953-98ab-2449037866d0"
+              sourceElement="#ebb83cd0-ce64-4800-bb46-bf66e6535b28"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="8fc579e3-3e40-4756-a031-8048b1735111" name="FunctionalExchange 1"
+              target="#c4b58a5b-7b59-4878-a3b0-98f81d84a460" source="#aaa41e95-09cf-473d-b30c-dee08c408b69"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="0b85472a-8a4d-44a0-99f2-6cb79e6945ee" name="FunctionalExchange 2"
+              target="#20543c0a-fb02-47c0-89c9-f288431d83b6" source="#76efc73d-fb3e-44c6-aa11-313be1ed4e1e"
+              exchangedItems="#b8ef9338-4c6f-4951-8820-cb841b3741bc"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="ece2c7e5-af25-439c-a094-8a9cba1aab74" name="FunctionalExchange 3"
+              target="#b8fab683-692d-4f60-971e-c5c34920b0d6" source="#20116911-ea74-4033-8245-3d7c09b859fa"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="f349c3cc-6cd7-4a5a-9bbb-62280771e9e9" name="FunctionalExchange 4"
+              target="#9b38b880-8d21-4d07-97a8-e4b04b474160" source="#15df1dec-08b7-48e7-97fb-81c4eaa6583a"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="c1c0e336-1ed8-412e-832a-50fc89e69031" name="FunctionalExchange 5"
+              target="#53e0e8dd-540d-4e76-a078-b21e8cbb9e97" source="#458d33d6-7c72-41d1-bcdd-cb2432387526"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="36284978-5a75-4cfe-ae33-91715655a912" name="FunctionalExchange 6"
+              target="#16345a05-7eb0-47c3-80c6-f128a1029612" source="#67e881e6-06ea-4273-9c49-7a56f3a8848d"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="070a7f1c-b035-438d-bfb1-0f5e9d551d5a" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="70a98659-e4bf-4eaf-9bc2-d9303ffbf4da" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="3b6963ba-b437-4218-8ded-897c93e749b7" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="575af067-4597-49d7-8ffe-e97033041a84" name="DataPkg 1">
+          <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+              id="0d775144-be57-4801-993e-4e030fb5ea31" name="DataPkg 2">
+            <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+                id="b8ef9338-4c6f-4951-8820-cb841b3741bc" name="ExchangeItem 1">
+              <ownedElements xsi:type="org.polarsys.capella.core.data.information:ExchangeItemElement"
+                  id="9263a02a-be7c-4dfa-ae43-c77f7a910b01" name="ExchangeItemElement 1"
+                  abstractType="#97a21031-aa2c-49cb-845c-bd3153143ea6" direction="UNSET"
+                  composite="true">
+                <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="6fc268ed-dd48-412a-8aa5-9cfe86c1b761" value="1"/>
+                <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="7e96938e-5b1b-4ed3-8042-d552754fb053" value="1"/>
+              </ownedElements>
+            </ownedExchangeItems>
+            <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+                id="97a21031-aa2c-49cb-845c-bd3153143ea6" name="Class 1"/>
+          </ownedDataPkgs>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="2cbb2303-1b52-49da-8511-8ae9d6e9657a" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="8f4f68a4-ef5a-4c69-9a2d-2b93c49550db"
+            name="Physical System" abstractType="#b87ce8fc-1d7f-4251-84b2-fe82826e17c8"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="b87ce8fc-1d7f-4251-84b2-fe82826e17c8" name="Physical System">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="4c895a3e-3f5b-4d6c-8f2d-f9d7d1767362"
+              name="PC 1" abstractType="#1345c718-6b74-4968-a445-3b38da65877d"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="e8293646-8f4a-4f13-8f15-aae14b887df4"
+              name="PC 2" abstractType="#2817e3a1-661a-4c35-85bc-119a86d9fc5e"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="019eed83-40ee-4eb6-b43e-efc1fb54e94d"
+              name="PC 3" abstractType="#f5d9f694-ead3-4889-8eb6-4ebfb2f300a4"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="59a1cea1-110f-446f-ae5c-9248c959f0d6"
+              name="PC 4" abstractType="#183a5ea4-224b-4ca1-a5e9-e28229897201"/>
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="e16c4b4c-c010-4a18-85de-d9031adbfcb2" targetElement="#09082358-e0a0-49a6-b44f-98775424c4af"
+              sourceElement="#b87ce8fc-1d7f-4251-84b2-fe82826e17c8"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="1345c718-6b74-4968-a445-3b38da65877d" name="PC 1" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="08ee4bd6-cad4-4a1c-b374-b998eb95bf21" targetElement="#e935f18e-6235-442c-8e5d-e280cf493d6e"
+                sourceElement="#1345c718-6b74-4968-a445-3b38da65877d"/>
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="1c1e17b9-2fe9-4681-a863-0ddee5342ed8" targetElement="#972c1a2f-3822-4061-98ca-e9d8b6f62e27"
+                sourceElement="#1345c718-6b74-4968-a445-3b38da65877d"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="2817e3a1-661a-4c35-85bc-119a86d9fc5e" name="PC 2" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="9f043a02-acfd-4bbe-9c66-23125ca6b128" targetElement="#26bb97ef-c46c-46cd-91c3-d39007d2dca5"
+                sourceElement="#2817e3a1-661a-4c35-85bc-119a86d9fc5e"/>
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="b17d9ecb-3786-4767-a633-3faa346ccee2" targetElement="#08a1c332-e40a-4914-9f8b-f6b2e470a1d7"
+                sourceElement="#2817e3a1-661a-4c35-85bc-119a86d9fc5e"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="f5d9f694-ead3-4889-8eb6-4ebfb2f300a4" name="PC 3" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="c39df5da-54ae-4b3d-92a1-ad803b09de35" targetElement="#2e7c03d8-2a3a-4df4-a26f-3f0977c4457d"
+                sourceElement="#f5d9f694-ead3-4889-8eb6-4ebfb2f300a4"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="183a5ea4-224b-4ca1-a5e9-e28229897201" name="PC 4" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="d2ae2254-34bf-4b2c-ba10-779d6f6d93ff" targetElement="#5c9e96e2-8a95-49ff-9b01-3a233322534a"
+                sourceElement="#183a5ea4-224b-4ca1-a5e9-e28229897201"/>
+          </ownedPhysicalComponents>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="bde07b0a-78a6-4d7a-95d6-56dbec2dbacc" targetElement="#ad28d6dc-4037-4b17-9fe0-801c562f9cd3"
+          sourceElement="#c409f227-d1c9-47eb-bb0a-f7fcfb42aaee"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="305bac46-ee59-4420-890f-e5a770ffd3fb" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="e4548848-6e0f-4739-b235-c9f988b86306" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="e6e28ae0-7bca-46a8-9136-9799c32ace59" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="772d1a6a-f010-4d6e-9aa7-ab5346b426ff"
+            name="System" abstractType="#28485b12-c19c-4718-81ab-c2f3d01ba382"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="28485b12-c19c-4718-81ab-c2f3d01ba382" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="ef522fac-7a23-44da-82af-dd4c30d26732" targetElement="#b87ce8fc-1d7f-4251-84b2-fe82826e17c8"
+              sourceElement="#28485b12-c19c-4718-81ab-c2f3d01ba382"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="c6ebeef7-2357-4cc7-80fa-fdd554703e1c" targetElement="#c409f227-d1c9-47eb-bb0a-f7fcfb42aaee"
+          sourceElement="#305bac46-ee59-4420-890f-e5a770ffd3fb"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="fe263e37-acb5-441c-8fd0-b877b44d3b3e" name="ExternalFunctionExchangeItemNotTransitionned">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="0d7e2d33-eee9-4344-b74d-a29c1e403df8" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="8161eff0-278c-4587-b09d-5abfa53f0043" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="5f33a4be-1657-47ed-8b97-b1b4453e5db1" name="Root System Function"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="d70eec1c-a128-41e4-85b2-b638380adb20" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="94732fbb-4ca7-42da-86d4-09887caddfae" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="986a5ef8-0ef0-43fd-9b00-b5c9d3107454" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="06a01af9-66a9-4c73-adf6-4aea9601dbae" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="4c888fc2-e8fa-4b1e-aab5-3f1fc5eff0e4" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="6e73eab2-9b6b-46b6-b0ae-9728830fa0ae" name="True" abstractType="#4c888fc2-e8fa-4b1e-aab5-3f1fc5eff0e4"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="fd1ebc59-891b-44f7-8272-1dba7215ddc6" name="False" abstractType="#4c888fc2-e8fa-4b1e-aab5-3f1fc5eff0e4"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="56098536-16e9-4717-ae44-667f9a993e4f" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a7abcc5b-8f13-4a3d-ad30-ecbff9aef477" name="" abstractType="#56098536-16e9-4717-ae44-667f9a993e4f"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="1c28375a-03f2-48b6-b49e-3cd384354d5e" name="" abstractType="#56098536-16e9-4717-ae44-667f9a993e4f"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="682ec42f-b011-42c8-906f-56c9ac4e88c0" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="fe0c80ba-b78c-4879-8aa4-9f2179f285be" name="" abstractType="#0bd326eb-73c4-4175-be08-cddcf632e6b4"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="d86bcd55-2453-4304-bff9-a1c7dc87ec22" name="" abstractType="#0bd326eb-73c4-4175-be08-cddcf632e6b4"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="594e64e5-f9f9-465e-8b5a-fc6b95ecabdd" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="aedd8942-a1e4-46f0-8853-ac4b75d0a9ca" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="67dbff04-414e-45fd-9729-3a189eec262a" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="bbd4e82a-890e-4b35-9ace-6e92fb7ffaae" name="" abstractType="#67dbff04-414e-45fd-9729-3a189eec262a"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="14cfa681-0dca-4800-bf11-353fb2dbb89a" abstractType="#67dbff04-414e-45fd-9729-3a189eec262a"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="d48c808b-31bc-443c-9ff9-92da3580821d" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="0147d5ca-f2b3-4ce9-9ee4-18a3cc313e68" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="a1ad64df-d4da-4ab8-a299-68dc0188a279" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="41502a63-e947-4dc9-b561-1141df74ea70" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="d144bb5f-5054-49ff-94d0-766eea29b867" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="829f3f4c-07d0-45f3-b819-a8673671a299" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="ebb7ce09-717f-4ec3-a962-be8b0a385600" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="d27ba835-73ee-49a6-99c9-b0f972d21fa9" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="5ee7c2be-a57b-4523-964f-4b5d6ba444af" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a3387ec5-1a4c-48ed-87db-ab0f48b4ff78" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="c1d4717e-e43c-4c51-ab66-1ceafdcf1755" name="" abstractType="#a3387ec5-1a4c-48ed-87db-ab0f48b4ff78"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="0bd326eb-73c4-4175-be08-cddcf632e6b4" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="981a99b8-bc13-459f-9a8f-129155d747a0" name="" abstractType="#0bd326eb-73c4-4175-be08-cddcf632e6b4"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="50cd749c-7b6d-4363-9a29-f837a5e29d00" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="3b827b90-07b1-4f0d-9c5f-8c5a8e23b7e2" name="" abstractType="#50cd749c-7b6d-4363-9a29-f837a5e29d00"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="7fc6e925-0bee-40f3-a07d-b9d43767de6d" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="b95e7ea9-c286-4dac-bdce-e1cd9adf63ca" name="" abstractType="#7fc6e925-0bee-40f3-a07d-b9d43767de6d"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="ff22661c-1e74-4e52-8a0e-ee2fbbd98570" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="7669cda7-8c6f-4676-a306-02d6dff684f4"
+            name="System" abstractType="#828f7afd-371a-4c6b-81b0-1f270afd9788"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="828f7afd-371a-4c6b-81b0-1f270afd9788" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="0a06bdfa-ae10-4aa2-8ab4-0177d232bb3e" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="1326b33b-5135-4672-9045-7b6a9d705737" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="403d357e-1dc6-42c5-bfc6-8bb88931d8fa"
+          name="Missions"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="caf10d94-c6a6-41ed-9839-f9cfd126424e" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="4d04427c-5ac4-4324-a82f-e85bc5cf5718" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="e3228801-f583-43d5-91f7-902e9460ab5d" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="060c3912-34c0-43db-837a-bad9e6985db1" targetElement="#5f33a4be-1657-47ed-8b97-b1b4453e5db1"
+              sourceElement="#e3228801-f583-43d5-91f7-902e9460ab5d"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="0b9257d6-0cde-4fbf-a989-6439c229da82" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="e2d60992-d0fe-4d93-a8ad-32759bc79343" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="72db82f3-1b0f-4ac9-a6bc-b28fa742b10e" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="c8896c49-4852-4391-aa85-0b3ab92a7b02" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="94df9571-420a-4467-adfa-d7cd3ae23d29"
+            name="Logical System" abstractType="#85ee47af-35fd-4110-a22e-f919bed99bfc"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="85ee47af-35fd-4110-a22e-f919bed99bfc" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="a12c89c4-6a8c-480a-8dda-136b25bffe1d" targetElement="#828f7afd-371a-4c6b-81b0-1f270afd9788"
+              sourceElement="#85ee47af-35fd-4110-a22e-f919bed99bfc"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="0d9ec135-edea-4ca6-a2cc-8e308910466b" targetElement="#0d7e2d33-eee9-4344-b74d-a29c1e403df8"
+          sourceElement="#caf10d94-c6a6-41ed-9839-f9cfd126424e"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="04325222-c4a7-4e4f-b734-d993e46b8426" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="068f74b2-36ce-42fb-b7f4-0acd40f82abe" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="9da48c2c-edaf-4572-818a-ed0804b6b74f" name="Root Physical Function">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="725fde1b-8bbb-4c9d-873c-140aacd7b0d4" name="FunctionalChain 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="f55e3eb3-dc9e-4c70-a5b9-9719b925ae93" involved="#d8b896c0-34b8-4161-bb71-b55c34749b13"
+                source="#6f49a6f3-e29d-4ea3-91fe-82716d939164" target="#fa90988a-c9a5-4aae-bab2-693d7d433a03"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="fa90988a-c9a5-4aae-bab2-693d7d433a03" involved="#d081995f-5d65-494f-9260-bd6e083a9dba"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="6f49a6f3-e29d-4ea3-91fe-82716d939164" involved="#c06a4a94-e4bd-43a8-9e46-9b072a76ed43"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="ec09651a-a694-466e-b71e-11cdfb47788b" involved="#f7d34d23-8f17-44fb-9e46-7ae195e36332"
+                source="#fa90988a-c9a5-4aae-bab2-693d7d433a03" target="#cc714806-b866-4e77-ba46-61c136f97948"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="cc714806-b866-4e77-ba46-61c136f97948" involved="#23398404-4514-474a-99a1-9912bf74ddb8"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="5c5c1241-5d3d-4a1e-923a-0358aab0b757" involved="#e5c78948-2800-4829-abe4-6c1e17810209"
+                source="#cc714806-b866-4e77-ba46-61c136f97948" target="#b5ecea1f-f1c0-4ad0-9f14-4ca4310bc787"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="b5ecea1f-f1c0-4ad0-9f14-4ca4310bc787" involved="#36d8b665-b1c6-46d4-af4e-a37295fc844f"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="78bfbff3-8eff-48c5-bcae-ef841c9e089f" involved="#049d4262-c81a-4ad1-a660-bf7278a62f76"
+                source="#b5ecea1f-f1c0-4ad0-9f14-4ca4310bc787" target="#4b2f6886-9c3d-4cf7-b7cb-d4f5aeb7d48c"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="4b2f6886-9c3d-4cf7-b7cb-d4f5aeb7d48c" involved="#feb96f1c-4f45-4e76-8ab1-c21c7b5cb1bb"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink"
+                id="9f3b09c8-0e3c-450f-8aa1-40c4c6042477" involved="#3dafb704-85b8-405a-a60b-503c7ff58682"
+                source="#4b2f6886-9c3d-4cf7-b7cb-d4f5aeb7d48c" target="#7d7efded-f49e-449f-a3f8-d22fb6446d3c"/>
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
+                id="7d7efded-f49e-449f-a3f8-d22fb6446d3c" involved="#0fe91acb-d03a-4586-bf84-338a911c0304"/>
+          </ownedFunctionalChains>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="c06a4a94-e4bd-43a8-9e46-9b072a76ed43" name="PhysicalFunction 1">
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="9a6838bb-78b5-4a14-a08c-e9506aeced19" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="0fe91acb-d03a-4586-bf84-338a911c0304" name="PhysicalFunction 2">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="12534fb3-618d-42f2-b9ae-19ffdea6cbff" name="FIP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="d081995f-5d65-494f-9260-bd6e083a9dba" name="PhysicalFunction 3">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="dc018752-ebcd-46f2-b091-0e6123bd125a" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="cb960bae-a98f-47f6-9f48-0280585b4508" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="23398404-4514-474a-99a1-9912bf74ddb8" name="PhysicalFunction 4">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="d9699fad-0420-413d-8b79-dacb7a088b03" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="2c61db88-001e-47df-9983-df184c4f5849" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="36d8b665-b1c6-46d4-af4e-a37295fc844f" name="PhysicalFunction 5">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="a91e19cf-77b5-4805-89c6-4b3ec0ef3d6b" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="bd850414-c364-4d86-a01f-38d6725af4e8" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+              id="feb96f1c-4f45-4e76-8ab1-c21c7b5cb1bb" name="PhysicalFunction 6">
+            <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
+                id="40e733b2-b197-4e8b-ae86-03087c0de781" name="FIP 1"/>
+            <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
+                id="e9f05f79-483f-4682-bde7-5e4ace6eae8e" name="FOP 1"/>
+          </ownedFunctions>
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="4010ed34-9f13-4360-a8be-4ba68c2cb8e5" targetElement="#e3228801-f583-43d5-91f7-902e9460ab5d"
+              sourceElement="#9da48c2c-edaf-4572-818a-ed0804b6b74f"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="d8b896c0-34b8-4161-bb71-b55c34749b13" name="FunctionalExchange 1"
+              target="#dc018752-ebcd-46f2-b091-0e6123bd125a" source="#9a6838bb-78b5-4a14-a08c-e9506aeced19"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="f7d34d23-8f17-44fb-9e46-7ae195e36332" name="FunctionalExchange 2"
+              target="#d9699fad-0420-413d-8b79-dacb7a088b03" source="#cb960bae-a98f-47f6-9f48-0280585b4508"
+              exchangedItems="#886b29f0-f702-48bb-bd64-6e8470de7fd6"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="e5c78948-2800-4829-abe4-6c1e17810209" name="FunctionalExchange 3"
+              target="#a91e19cf-77b5-4805-89c6-4b3ec0ef3d6b" source="#2c61db88-001e-47df-9983-df184c4f5849"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="049d4262-c81a-4ad1-a660-bf7278a62f76" name="FunctionalExchange 4"
+              target="#40e733b2-b197-4e8b-ae86-03087c0de781" source="#bd850414-c364-4d86-a01f-38d6725af4e8"/>
+          <ownedFunctionalExchanges xsi:type="org.polarsys.capella.core.data.fa:FunctionalExchange"
+              id="3dafb704-85b8-405a-a60b-503c7ff58682" name="FunctionalExchange 5"
+              target="#12534fb3-618d-42f2-b9ae-19ffdea6cbff" source="#e9f05f79-483f-4682-bde7-5e4ace6eae8e"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="b82550c6-a86c-48f5-81af-fac8dd1fa267" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="6b8aef81-9db8-4d87-a0a6-9871ce174550" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="a197fbd1-68f0-40d5-82a8-12569998b512" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="0ff48036-3091-4bf6-823e-f2c01fa3b35f" name="DataPkg 1">
+          <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+              id="6c00e5b5-e766-49f2-b026-0f3aa74913d1" name="DataPkg 2">
+            <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+                id="886b29f0-f702-48bb-bd64-6e8470de7fd6" name="ExchangeItem 1">
+              <ownedElements xsi:type="org.polarsys.capella.core.data.information:ExchangeItemElement"
+                  id="046931d1-db10-4010-aced-56142ee87cb1" name="ExchangeItemElement 1"
+                  abstractType="#85d0d044-4bf1-41eb-91a8-3f07c0c6c926" direction="UNSET"
+                  composite="true">
+                <ownedMinCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="6426264f-3dd1-4a24-a8be-d34692ee1780" value="1"/>
+                <ownedMaxCard xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="4d340596-b907-4975-927f-aa63542d6bb0" value="1"/>
+              </ownedElements>
+            </ownedExchangeItems>
+            <ownedClasses xsi:type="org.polarsys.capella.core.data.information:Class"
+                id="85d0d044-4bf1-41eb-91a8-3f07c0c6c926" name="Class 1"/>
+          </ownedDataPkgs>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="dfcabe7b-7f00-4b54-b212-b606b0ff7c2e" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="08e433c2-e037-43f2-a163-8fc7ecdc2e62"
+            name="Physical System" abstractType="#081c0909-48fa-4249-9f3b-078ed9075470"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="081c0909-48fa-4249-9f3b-078ed9075470" name="Physical System">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="9a4b4604-e6a1-4c7a-8a41-568806b8011b"
+              name="PC 1" abstractType="#3d5c5246-6da4-4a4d-94e3-09c2fdba5b2d"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="34c2ab21-f649-421a-a673-e6817c2b3202"
+              name="PC 2" abstractType="#ddfc5fe8-08aa-457c-8835-599884e5e328"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="c1eced85-cb5b-40cc-ad03-5d151cfa9313"
+              name="PC 3" abstractType="#509bc652-5123-4cf5-b985-1fa518cc1c22"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="9aa291d3-04cc-47a4-9db8-86877680df44"
+              name="PC 4" abstractType="#48379684-77bc-46ab-8f0c-5c619acb52d1"/>
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="fb9d546c-c60e-478e-8b42-d3ccd8f5c048" targetElement="#85ee47af-35fd-4110-a22e-f919bed99bfc"
+              sourceElement="#081c0909-48fa-4249-9f3b-078ed9075470"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="3d5c5246-6da4-4a4d-94e3-09c2fdba5b2d" name="PC 1" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="15b021a5-5d19-48ed-9f27-ce85023e9cb5" targetElement="#c06a4a94-e4bd-43a8-9e46-9b072a76ed43"
+                sourceElement="#3d5c5246-6da4-4a4d-94e3-09c2fdba5b2d"/>
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="6dd7cae5-8a7c-4a50-8f9d-90732ea033e1" targetElement="#0fe91acb-d03a-4586-bf84-338a911c0304"
+                sourceElement="#3d5c5246-6da4-4a4d-94e3-09c2fdba5b2d"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="ddfc5fe8-08aa-457c-8835-599884e5e328" name="PC 2" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="c51d5512-ba6e-4ab7-888b-e3100d99014b" targetElement="#d081995f-5d65-494f-9260-bd6e083a9dba"
+                sourceElement="#ddfc5fe8-08aa-457c-8835-599884e5e328"/>
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="321e2e25-1356-44a0-9f77-f6db357aacc2" targetElement="#23398404-4514-474a-99a1-9912bf74ddb8"
+                sourceElement="#ddfc5fe8-08aa-457c-8835-599884e5e328"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="509bc652-5123-4cf5-b985-1fa518cc1c22" name="PC 3" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="bb80e8de-9462-4912-8018-f657de7dfac6" targetElement="#feb96f1c-4f45-4e76-8ab1-c21c7b5cb1bb"
+                sourceElement="#509bc652-5123-4cf5-b985-1fa518cc1c22"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="48379684-77bc-46ab-8f0c-5c619acb52d1" name="PC 4" nature="BEHAVIOR">
+            <ownedFunctionalAllocation xsi:type="org.polarsys.capella.core.data.fa:ComponentFunctionalAllocation"
+                id="05c61d4b-15fc-45cc-a312-f6c32e89f080" targetElement="#36d8b665-b1c6-46d4-af4e-a37295fc844f"
+                sourceElement="#48379684-77bc-46ab-8f0c-5c619acb52d1"/>
+          </ownedPhysicalComponents>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="27d098a0-21e4-44af-9c0d-e8abaca61239" targetElement="#caf10d94-c6a6-41ed-9839-f9cfd126424e"
+          sourceElement="#04325222-c4a7-4e4f-b734-d993e46b8426"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/AllMixedTests.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/AllMixedTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 THALES GLOBAL SERVICES.
+ * Copyright (c) 2016, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,10 +31,12 @@ public class AllMixedTests extends BasicTestSuite {
   protected List<BasicTestArtefact> getTests() {
     final List<BasicTestArtefact> tests = new ArrayList<BasicTestArtefact>();
 
+    tests.addAll(testsFor(AllocatedExchangeItemTest.class));
+
     tests.addAll(testsFor(FakeExchange.class));
     tests.addAll(testsFor(CycleMerge.class));
     tests.addAll(testsFor(CyclePremices.class));
-    
+
     tests.add(new IncrementalModeTest());
 
     tests.addAll(testsFor(FakeExchangeChain.Always.class));
@@ -53,6 +55,9 @@ public class AllMixedTests extends BasicTestSuite {
     tests.add(new DataValuesTest.Interphase());
 
     tests.addAll(testsFor(ExchangeCategoryTest.class));
+    tests.addAll(testsFor(ExternalFunctionExchangeItemTransitionnedTest.class));
+    tests.addAll(testsFor(ExternalFunctionExchangeItemNotTransitionnedTest.class));
+
     tests.addAll(testsFor(FakeChainInvolvementLink.Always.class));
     tests.addAll(testsFor(FunctionalChainLoopTest.class));
     tests.addAll(testsFor(FunctionalChainScopeTest.class));

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/AllocatedExchangeItemTest.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/AllocatedExchangeItemTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.transition.system2subsystem.tests.mixed;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.polarsys.capella.core.data.cs.CsPackage;
+import org.polarsys.capella.core.data.fa.FaPackage;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Crossphase;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Interphase;
+
+/**
+ * Allocated Exchange Items test
+ */
+public class AllocatedExchangeItemTest extends System2SubsystemTest implements Interphase, Crossphase {
+
+  public static String BEHAVIOR_PC = "5892b130-2d27-4b33-aa6b-071ebf8b7b2d"; //$NON-NLS-1$
+
+  // Should be transitioned
+
+  public static String EI_FOP1 = "fd4e8de4-d839-438c-9da4-3653743bb129"; //$NON-NLS-1$
+  public static String EI_FIP1 = "d335f117-c19a-4466-91f2-e7dc83dd4218"; //$NON-NLS-1$
+  public static String EI_FE1 = "f3685b18-6179-4aea-b249-91b4dcd537a9"; //$NON-NLS-1$
+  public static String EI_CE1 = "69d78fb0-3614-485b-9ce6-b9360866175c"; //$NON-NLS-1$
+  public static String EI_ITF1 = "cb34546f-7606-47dc-863b-bb2065f3036a"; //$NON-NLS-1$
+  public static String EI_ITF2 = "52b962c9-e551-4e50-b0ef-42eddd648b42"; //$NON-NLS-1$
+
+  public static String FOP1 = "9eb87c76-fa5b-42c2-b5fa-b09077e13a76"; //$NON-NLS-1$
+  public static String FIP1 = "0c17a944-894c-464b-8c57-6c3736b65711"; //$NON-NLS-1$
+  public static String FE1 = "bb4547d2-bf76-47b9-a299-e216fa557330"; //$NON-NLS-1$
+  public static String CE1 = "293edf7c-81df-40d2-affc-98dde43154b5"; //$NON-NLS-1$
+  public static String ITF1 = "974ded47-c9a6-4943-90e4-bd7bfedcafb1"; //$NON-NLS-1$
+  public static String ITF2 = "16cc6322-3a12-4a2e-9b6a-b04943bd21c9"; //$NON-NLS-1$
+
+  @Override
+  protected Collection<?> getProjectionElements() {
+    return getObjects(BEHAVIOR_PC);
+  }
+
+  @Override
+  protected void verify() {
+    mustBeTransitionedAndLinkedTo(FOP1, EI_FOP1, FaPackage.Literals.FUNCTION_OUTPUT_PORT__OUTGOING_EXCHANGE_ITEMS);
+    mustBeTransitionedAndLinkedTo(FIP1, EI_FIP1, FaPackage.Literals.FUNCTION_INPUT_PORT__INCOMING_EXCHANGE_ITEMS);
+    mustBeTransitionedAndLinkedTo(FE1, EI_FE1, FaPackage.Literals.FUNCTIONAL_EXCHANGE__EXCHANGED_ITEMS);
+    mustBeTransitioned(EI_CE1); // Could not find COMPONENT_EXCHANGE__CONVOYED_INFORMATIONS
+    mustBeTransitionedAndLinkedTo(ITF1, EI_ITF1, CsPackage.Literals.INTERFACE__EXCHANGE_ITEMS);
+    mustBeTransitionedAndLinkedTo(ITF2, EI_ITF2, CsPackage.Literals.INTERFACE__EXCHANGE_ITEMS);
+  }
+
+  @Override
+  public List<String> getRequiredTestModels() {
+    return Arrays.asList("AllocatedExchangeItemTest", "output"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+}

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/ExternalFunctionExchangeItemNotTransitionnedTest.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/ExternalFunctionExchangeItemNotTransitionnedTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.transition.system2subsystem.tests.mixed;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Crossphase;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Interphase;
+
+/**
+ * Allocated Exchange Items test
+ */
+public class ExternalFunctionExchangeItemNotTransitionnedTest extends System2SubsystemTest
+    implements Interphase, Crossphase {
+
+  public static String BEHAVIOR_PC = "4c895a3e-3f5b-4d6c-8f2d-f9d7d1767362"; //$NON-NLS-1$
+
+  // Should not be transitioned
+
+  public static String FE = "f7d34d23-8f17-44fb-9e46-7ae195e36332"; //$NON-NLS-1$
+  public static String EI = "886b29f0-f702-48bb-bd64-6e8470de7fd6"; //$NON-NLS-1$
+  public static String EIE = "046931d1-db10-4010-aced-56142ee87cb1"; //$NON-NLS-1$
+  public static String CLASS = "Id  85d0d044-4bf1-41eb-91a8-3f07c0c6c926"; //$NON-NLS-1$
+  public static String DATAPKG_1 = "0ff48036-3091-4bf6-823e-f2c01fa3b35f"; //$NON-NLS-1$
+  public static String DATAPKG_2 = "6c00e5b5-e766-49f2-b026-0f3aa74913d1"; //$NON-NLS-1$
+
+  @Override
+  protected Collection<?> getProjectionElements() {
+    return getObjects(BEHAVIOR_PC);
+  }
+
+  @Override
+  protected void verify() {
+    shouldNotBeTransitioned(FE);
+    shouldNotBeTransitioned(FE);
+    shouldNotBeTransitioned(EI);
+    shouldNotBeTransitioned(CLASS);
+    shouldNotBeTransitioned(DATAPKG_1);
+    shouldNotBeTransitioned(DATAPKG_2);
+  }
+
+  @Override
+  public List<String> getRequiredTestModels() {
+    return Arrays.asList("ExternalFunctionExchangeItemTransition", "output"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+}

--- a/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/ExternalFunctionExchangeItemTransitionnedTest.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem.tests.ju/src/org/polarsys/capella/transition/system2subsystem/tests/mixed/ExternalFunctionExchangeItemTransitionnedTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.transition.system2subsystem.tests.mixed;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.polarsys.capella.core.data.fa.FaPackage;
+import org.polarsys.capella.core.data.information.InformationPackage;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Crossphase;
+import org.polarsys.capella.transition.system2subsystem.tests.System2SubsystemTest.Interphase;
+
+/**
+ * Allocated Exchange Items test
+ */
+public class ExternalFunctionExchangeItemTransitionnedTest extends System2SubsystemTest
+    implements Interphase, Crossphase {
+
+  public static String BEHAVIOR_PC = "4c895a3e-3f5b-4d6c-8f2d-f9d7d1767362"; //$NON-NLS-1$
+
+  // Should be transitioned
+
+  public static String FE = "0b85472a-8a4d-44a0-99f2-6cb79e6945ee"; //$NON-NLS-1$
+  public static String EI = "b8ef9338-4c6f-4951-8820-cb841b3741bc"; //$NON-NLS-1$
+  public static String EIE = "9263a02a-be7c-4dfa-ae43-c77f7a910b01"; //$NON-NLS-1$
+  public static String CLASS = "97a21031-aa2c-49cb-845c-bd3153143ea6"; //$NON-NLS-1$
+  public static String DATAPKG_1 = "575af067-4597-49d7-8ffe-e97033041a84"; //$NON-NLS-1$
+  public static String DATAPKG_2 = "0d775144-be57-4801-993e-4e030fb5ea31"; //$NON-NLS-1$
+
+  @Override
+  protected Collection<?> getProjectionElements() {
+    return getObjects(BEHAVIOR_PC);
+  }
+
+  @Override
+  protected void verify() {
+    mustBeTransitioned(FE);
+    mustBeTransitionedAndLinkedTo(FE, EI, FaPackage.Literals.FUNCTIONAL_EXCHANGE__EXCHANGED_ITEMS);
+    mustBeTransitionedAndLinkedTo(EI, EIE, InformationPackage.Literals.EXCHANGE_ITEM__OWNED_ELEMENTS);
+    mustBeTransitioned(CLASS);
+    mustBeTransitioned(DATAPKG_1);
+    mustBeTransitioned(DATAPKG_2);
+  }
+
+  @Override
+  public List<String> getRequiredTestModels() {
+    return Arrays.asList("ExternalFunctionExchangeItemTransition", "output"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+}

--- a/plugins/org.polarsys.capella.transition.system2subsystem/src/org/polarsys/capella/transition/system2subsystem/handlers/scope/ExternalFunctionsScopeRetriever.java
+++ b/plugins/org.polarsys.capella.transition.system2subsystem/src/org/polarsys/capella/transition/system2subsystem/handlers/scope/ExternalFunctionsScopeRetriever.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,16 +14,14 @@ package org.polarsys.capella.transition.system2subsystem.handlers.scope;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.ecore.EObject;
 import org.polarsys.capella.common.data.activity.ActivityEdge;
 import org.polarsys.capella.core.data.fa.AbstractFunction;
-import org.polarsys.capella.core.data.fa.FunctionInputPort;
-import org.polarsys.capella.core.data.fa.FunctionOutputPort;
 import org.polarsys.capella.core.data.fa.FunctionalChain;
 import org.polarsys.capella.core.data.fa.FunctionalExchange;
 import org.polarsys.capella.core.data.helpers.fa.services.FunctionExt;
@@ -32,13 +30,7 @@ import org.polarsys.capella.core.transition.common.constants.ITransitionConstant
 import org.polarsys.capella.core.transition.common.handlers.contextscope.ContextScopeHandlerHelper;
 import org.polarsys.capella.core.transition.common.handlers.contextscope.IContextScopeHandler;
 import org.polarsys.capella.core.transition.common.handlers.scope.IScopeRetriever;
-import org.polarsys.capella.core.transition.common.rules.AbstractRule;
-import org.polarsys.capella.transition.system2subsystem.constants.ISubSystemConstants;
-import org.polarsys.kitalpha.transposer.rules.handler.api.IRulesHandler;
-import org.polarsys.kitalpha.transposer.rules.handler.exceptions.possibilities.MappingPossibilityResolutionException;
 import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IContext;
-import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IRule;
-import org.polarsys.kitalpha.transposer.rules.handler.rules.common.MappingPossibility;
 
 /**
  * A scope retriever to retrieve all exchanges that can be reused as a FakeExchange while FunctionalChain processing
@@ -63,8 +55,47 @@ public class ExternalFunctionsScopeRetriever implements IScopeRetriever {
    * {@inheritDoc}
    */
   public Collection<? extends EObject> retrieveRelatedElements(EObject source_p, IContext context_p) {
-    Collection<EObject> result = new LinkedList<EObject>();
+    HashSet<EObject> result = new HashSet<EObject>();
+    IContextScopeHandler scope = ContextScopeHandlerHelper.getInstance(context_p);
+    if (source_p instanceof AbstractFunction) {
+      AbstractFunction element = (AbstractFunction) source_p;
+      for (FunctionalExchange exchange : getFE(element, context_p)) {
+        AbstractFunction sourceFunction = (AbstractFunction) exchange.getSource().eContainer();
+        AbstractFunction targetFunction = (AbstractFunction) exchange.getTarget().eContainer();
+        AbstractFunction oppositeFunction = element.equals(targetFunction) ? sourceFunction : targetFunction;
+        if (isLinkToPrimaryFunction(oppositeFunction, context_p)) {
+          for (FunctionalExchange fe : getFE(oppositeFunction, context_p)) {
+            if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, fe, context_p)) {
+              AbstractFunction source = (AbstractFunction) fe.getSource().eContainer();
+              AbstractFunction target = (AbstractFunction) fe.getTarget().eContainer();
+              AbstractFunction opposite = oppositeFunction.equals(target) ? source : target;
 
+              if (isLinkToPrimaryFunction(opposite, context_p)) {
+
+                Collection<FunctionalExchange> srcFes = getFE(source, context_p);
+                Collection<FunctionalExchange> trgFes = getFE(target, context_p);
+
+                Collection<FunctionalChain> srcFcs = getFunctionalChains(srcFes);
+                Collection<FunctionalChain> trgFcs = getFunctionalChains(trgFes);
+                Collection<FunctionalChain> feFcs = fe.getInvolvingFunctionalChains();
+
+                Collection<FunctionalChain> retained = new ArrayList<FunctionalChain>();
+                retained.addAll(feFcs);
+                retained.retainAll(srcFcs);
+                retained.retainAll(trgFcs);
+
+                if (!retained.isEmpty()) {
+                  if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, fe, context_p)) {
+                    scope.add(ITransitionConstants.SOURCE_SCOPE, fe, context_p);
+                    result.add(fe);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     return result;
   }
 
@@ -112,125 +143,7 @@ public class ExternalFunctionsScopeRetriever implements IScopeRetriever {
    * {@inheritDoc}
    */
   public Collection<? extends EObject> retrieveSharedElements(IContext context_p) {
-
-    HashSet<EObject> result = new HashSet<EObject>();
-    Collection<AbstractFunction> linkToPrimary = new ArrayList<AbstractFunction>();
-
-    IContextScopeHandler scope = ContextScopeHandlerHelper.getInstance(context_p);
-    for (EObject object : scope.getCollection(ITransitionConstants.SOURCE_SCOPE, context_p)) {
-
-      if (object instanceof AbstractFunction) {
-        AbstractFunction element = (AbstractFunction) object;
-
-        for (FunctionalExchange exchange : getFE(element, context_p)) {
-          AbstractFunction source = (AbstractFunction) exchange.getSource().eContainer();
-          AbstractFunction target = (AbstractFunction) exchange.getTarget().eContainer();
-          AbstractFunction opposite = element.equals(target) ? source : target;
-          if (isLinkToPrimaryFunction(opposite, context_p)) {
-            linkToPrimary.add(opposite);
-          }
-        }
-      }
-    }
-
-    for (AbstractFunction function : linkToPrimary) {
-      scope.add(ISubSystemConstants.SCOPE_SECONDARY_ELEMENT, function, context_p);
-
-      for (FunctionalExchange exchange : getFE(function, context_p)) {
-        if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, exchange, context_p)) {
-
-          AbstractFunction source = (AbstractFunction) exchange.getSource().eContainer();
-          AbstractFunction target = (AbstractFunction) exchange.getTarget().eContainer();
-          AbstractFunction opposite = function.equals(target) ? source : target;
-
-          if (isLinkToPrimaryFunction(opposite, context_p)) {
-
-            Collection<FunctionalExchange> srcFes = getFE(source, context_p);
-            Collection<FunctionalExchange> trgFes = getFE(target, context_p);
-
-            Collection<FunctionalChain> srcFcs = getFunctionalChains(srcFes);
-            Collection<FunctionalChain> trgFcs = getFunctionalChains(trgFes);
-            Collection<FunctionalChain> feFcs = exchange.getInvolvingFunctionalChains();
-
-            Collection<FunctionalChain> retained = new ArrayList<FunctionalChain>();
-            retained.addAll(feFcs);
-            retained.retainAll(srcFcs);
-            retained.retainAll(trgFcs);
-
-            if (!retained.isEmpty()) {
-
-              for (EObject related : getRelatedElements(exchange)) {
-                if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, related, context_p)) {
-                  scope.add(ISubSystemConstants.SCOPE_SECONDARY_ELEMENT, related, context_p);
-                }
-                result.add(related);
-              }
-
-              if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, source, context_p)) {
-                scope.add(ISubSystemConstants.SCOPE_SECONDARY_ELEMENT, source, context_p);
-                result.add(source);
-              }
-              if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, target, context_p)) {
-                scope.add(ISubSystemConstants.SCOPE_SECONDARY_ELEMENT, target, context_p);
-                result.add(target);
-              }
-              if (!scope.contains(ITransitionConstants.SOURCE_SCOPE, exchange, context_p)) {
-                scope.add(ISubSystemConstants.SCOPE_SECONDARY_ELEMENT, exchange, context_p);
-                result.add(exchange);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    ensureTransposer(result, context_p);
-    return result;
-  }
-
-  /**
-   * This method ensure that the IContext is correctly setted in the rules that will transform elements before premices computation
-   */
-  protected void ensureTransposer(Collection<EObject> elements_p, IContext context_p) {
-    IRulesHandler ruleHandler = (IRulesHandler) context_p.get(ITransitionConstants.RULES_HANDLER);
-    for (EObject object : elements_p) {
-      try {
-        if (object != null) {
-          MappingPossibility mapping = ruleHandler.getApplicablePossibility(object);
-          if (mapping != null) {
-            IRule<?> rule = ruleHandler.getApplicablePossibility(object).getCompleteRule();
-            if ((rule != null) && (rule instanceof AbstractRule)) {
-              AbstractRule deeperRule = (AbstractRule) rule;
-              deeperRule.retrieveContainers(object, context_p);
-            }
-          }
-        }
-      } catch (MappingPossibilityResolutionException exception_p) {
-        // Nothing to report
-      }
-    }
-
-  }
-
-  protected Collection<EObject> getRelatedElements(FunctionalExchange exchange_p) {
-    Collection<EObject> result = new ArrayList<EObject>();
-    result.add(exchange_p);
-    result.addAll(exchange_p.getExchangedItems());
-    result.addAll(exchange_p.getCategories());
-
-    result.add(FunctionalExchangeExt.getSourceFunction(exchange_p));
-    result.add(FunctionalExchangeExt.getTargetFunction(exchange_p));
-
-    if (exchange_p.getTarget() instanceof FunctionInputPort) {
-      result.add(exchange_p.getTarget());
-      result.addAll(((FunctionInputPort) exchange_p.getTarget()).getIncomingExchangeItems());
-    }
-    if (exchange_p.getSource() instanceof FunctionOutputPort) {
-      result.add(exchange_p.getSource());
-      result.addAll(((FunctionOutputPort) exchange_p.getSource()).getOutgoingExchangeItems());
-    }
-
-    return result;
+    return Collections.emptyList();
   }
 
   public static boolean isLinkToPrimaryFunction(AbstractFunction function, IContext context_p) {
@@ -290,7 +203,8 @@ public class ExternalFunctionsScopeRetriever implements IScopeRetriever {
    * @return
    */
   public static boolean isPrimaryFunction(AbstractFunction function, IContext context_p) {
-    return ContextScopeHandlerHelper.getInstance(context_p).contains(ITransitionConstants.SOURCE_SCOPE, function, context_p);
+    return ContextScopeHandlerHelper.getInstance(context_p).contains(ITransitionConstants.SOURCE_SCOPE, function,
+        context_p);
   }
 
 }


### PR DESCRIPTION
Fixed issue where external functions would transition their exchangeItems but not their contents nor their hierarchy Exchange items are now properly transited with their content, linked datatypes and hierarchy

Added unit test to cover these cases
Added unit test to cover the allocated exchange item on FIP case

Change-Id: I61c2692958f110758d1cb6b49837a6b75f504d51
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>